### PR TITLE
Goal unit and metrics updates, selected weekdays, start/end dates

### DIFF
--- a/Count+CoreDataProperties.swift
+++ b/Count+CoreDataProperties.swift
@@ -19,6 +19,7 @@ extension Count {
     @NSManaged public var createdAt: Date?
     @NSManaged public var date: Date?
     @NSManaged public var id: UUID?
+    @NSManaged public var amount: Int16
     @NSManaged public var progress: Progress?
     
     public var wrappedCreatedDate: Date {

--- a/Habiscus.xcodeproj/project.pbxproj
+++ b/Habiscus.xcodeproj/project.pbxproj
@@ -173,9 +173,9 @@
 		7EFA41902A8021CD00D2F8E3 /* DataManagers */ = {
 			isa = PBXGroup;
 			children = (
+				7E1261612A742200009F15C9 /* HabitManager.swift */,
 				7EA9FEA92A82F6960084A843 /* Bundle-Decodable.swift */,
 				7E34D87D2A82F47300A7D649 /* EmojiManager.swift */,
-				7E1261612A742200009F15C9 /* HabitManager.swift */,
 				7E67A7AF2A6B5A88001E0C23 /* FileManager.swift */,
 				7E93174E2A7D84160074E210 /* HapticManager.swift */,
 				7E80A7EC2A7D9CFB0035F658 /* SoundManager.swift */,

--- a/Habiscus.xcodeproj/project.pbxproj
+++ b/Habiscus.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7E13C7562A8441EE006EBA82 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E13C7552A8441EE006EBA82 /* StatisticsView.swift */; };
 		7E34D8762A82EE9700A7D649 /* IconPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E34D8752A82EE9700A7D649 /* IconPickerView.swift */; };
 		7E34D87E2A82F47300A7D649 /* EmojiManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E34D87D2A82F47300A7D649 /* EmojiManager.swift */; };
+		7E3BE9142A8C27EA008C1503 /* AddCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3BE9132A8C27EA008C1503 /* AddCountView.swift */; };
 		7E67A7A02A6B52B9001E0C23 /* HabiscusApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E67A79F2A6B52B9001E0C23 /* HabiscusApp.swift */; };
 		7E67A7A22A6B52B9001E0C23 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E67A7A12A6B52B9001E0C23 /* ContentView.swift */; };
 		7E67A7A42A6B52BA001E0C23 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7E67A7A32A6B52BA001E0C23 /* Assets.xcassets */; };
@@ -51,6 +52,7 @@
 		7E13C7552A8441EE006EBA82 /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
 		7E34D8752A82EE9700A7D649 /* IconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerView.swift; sourceTree = "<group>"; };
 		7E34D87D2A82F47300A7D649 /* EmojiManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiManager.swift; sourceTree = "<group>"; };
+		7E3BE9132A8C27EA008C1503 /* AddCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCountView.swift; sourceTree = "<group>"; };
 		7E67A79C2A6B52B9001E0C23 /* Habiscus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Habiscus.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E67A79F2A6B52B9001E0C23 /* HabiscusApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabiscusApp.swift; sourceTree = "<group>"; };
 		7E67A7A12A6B52B9001E0C23 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -166,6 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				7EB7708F2A8423BE00559D73 /* IconView.swift */,
+				7E3BE9132A8C27EA008C1503 /* AddCountView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -324,6 +327,7 @@
 				7E1261702A7446B3009F15C9 /* Progress+CoreDataProperties.swift in Sources */,
 				7EF1E2B22A6EDE9C00DE3517 /* HabitRowView.swift in Sources */,
 				7E67A7A02A6B52B9001E0C23 /* HabiscusApp.swift in Sources */,
+				7E3BE9142A8C27EA008C1503 /* AddCountView.swift in Sources */,
 				7E8C91232A7302EF0006055C /* GoalCounterView.swift in Sources */,
 				7E12616F2A7446B3009F15C9 /* Progress+CoreDataClass.swift in Sources */,
 				7E67A7B02A6B5A88001E0C23 /* FileManager.swift in Sources */,

--- a/Habiscus.xcodeproj/project.pbxproj
+++ b/Habiscus.xcodeproj/project.pbxproj
@@ -26,9 +26,10 @@
 		7E8C91232A7302EF0006055C /* GoalCounterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8C91222A7302EF0006055C /* GoalCounterView.swift */; };
 		7E93174F2A7D84160074E210 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E93174E2A7D84160074E210 /* HapticManager.swift */; };
 		7EA68A782A79555A001C6067 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA68A772A79555A001C6067 /* Date.swift */; };
-		7EA6C3ED2A72950C00DA4C41 /* WeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA6C3EC2A72950C00DA4C41 /* WeekView.swift */; };
+		7EA6C3ED2A72950C00DA4C41 /* MultiWeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA6C3EC2A72950C00DA4C41 /* MultiWeekView.swift */; };
 		7EA6C3EF2A7295C100DA4C41 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA6C3EE2A7295C100DA4C41 /* Week.swift */; };
 		7EA9FEAA2A82F6960084A843 /* Bundle-Decodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EA9FEA92A82F6960084A843 /* Bundle-Decodable.swift */; };
+		7EAAB24D2A8BD9C00075F9EB /* WeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAAB24C2A8BD9C00075F9EB /* WeekView.swift */; };
 		7EB1C77A2A83E2A7008CB6C3 /* emoji.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EB1C7792A83E2A7008CB6C3 /* emoji.json */; };
 		7EB770902A8423BE00559D73 /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB7708F2A8423BE00559D73 /* IconView.swift */; };
 		7ECD695B2A7D31930096AF19 /* CalendarGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD695A2A7D31930096AF19 /* CalendarGridView.swift */; };
@@ -64,9 +65,10 @@
 		7E8C91222A7302EF0006055C /* GoalCounterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalCounterView.swift; sourceTree = "<group>"; };
 		7E93174E2A7D84160074E210 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		7EA68A772A79555A001C6067 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
-		7EA6C3EC2A72950C00DA4C41 /* WeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekView.swift; sourceTree = "<group>"; };
+		7EA6C3EC2A72950C00DA4C41 /* MultiWeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWeekView.swift; sourceTree = "<group>"; };
 		7EA6C3EE2A7295C100DA4C41 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		7EA9FEA92A82F6960084A843 /* Bundle-Decodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle-Decodable.swift"; sourceTree = "<group>"; };
+		7EAAB24C2A8BD9C00075F9EB /* WeekView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekView.swift; sourceTree = "<group>"; };
 		7EB1C7792A83E2A7008CB6C3 /* emoji.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = emoji.json; sourceTree = "<group>"; };
 		7EB7708F2A8423BE00559D73 /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		7ECD695A2A7D31930096AF19 /* CalendarGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarGridView.swift; sourceTree = "<group>"; };
@@ -210,7 +212,8 @@
 				7ED93E142A7AE2B0000C41B9 /* CountGridView.swift */,
 				7EA68A772A79555A001C6067 /* Date.swift */,
 				7EA6C3EE2A7295C100DA4C41 /* Week.swift */,
-				7EA6C3EC2A72950C00DA4C41 /* WeekView.swift */,
+				7EA6C3EC2A72950C00DA4C41 /* MultiWeekView.swift */,
+				7EAAB24C2A8BD9C00075F9EB /* WeekView.swift */,
 			);
 			path = Calendars;
 			sourceTree = "<group>";
@@ -300,7 +303,7 @@
 				7EA68A782A79555A001C6067 /* Date.swift in Sources */,
 				7E67A7A22A6B52B9001E0C23 /* ContentView.swift in Sources */,
 				7EE77DFB2A6DE0310058CDF8 /* Habit+CoreDataClass.swift in Sources */,
-				7EA6C3ED2A72950C00DA4C41 /* WeekView.swift in Sources */,
+				7EA6C3ED2A72950C00DA4C41 /* MultiWeekView.swift in Sources */,
 				7EE77DFC2A6DE0310058CDF8 /* Habit+CoreDataProperties.swift in Sources */,
 				7EF9C85B2A7B1DFC006E5130 /* CalendarView.swift in Sources */,
 				7E697DD42A843B84000EC5D8 /* HabitView.swift in Sources */,
@@ -315,6 +318,7 @@
 				7EE77DEC2A6DDC2E0058CDF8 /* DataController.swift in Sources */,
 				7EA6C3EF2A7295C100DA4C41 /* Week.swift in Sources */,
 				7EB770902A8423BE00559D73 /* IconView.swift in Sources */,
+				7EAAB24D2A8BD9C00075F9EB /* WeekView.swift in Sources */,
 				7EE77DFA2A6DE0310058CDF8 /* Count+CoreDataProperties.swift in Sources */,
 				7EA9FEAA2A82F6960084A843 /* Bundle-Decodable.swift in Sources */,
 				7E1261702A7446B3009F15C9 /* Progress+CoreDataProperties.swift in Sources */,

--- a/Habiscus.xcodeproj/project.pbxproj
+++ b/Habiscus.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		7EE77DFB2A6DE0310058CDF8 /* Habit+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE77DF72A6DE0310058CDF8 /* Habit+CoreDataClass.swift */; };
 		7EE77DFC2A6DE0310058CDF8 /* Habit+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE77DF82A6DE0310058CDF8 /* Habit+CoreDataProperties.swift */; };
 		7EF1E2B22A6EDE9C00DE3517 /* HabitRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF1E2B12A6EDE9C00DE3517 /* HabitRowView.swift */; };
+		7EF7DCC72A8D15C7007AF16C /* Weekday.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF7DCC62A8D15C7007AF16C /* Weekday.swift */; };
 		7EF9C85B2A7B1DFC006E5130 /* CalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EF9C85A2A7B1DFC006E5130 /* CalendarView.swift */; };
 /* End PBXBuildFile section */
 
@@ -83,6 +84,7 @@
 		7EE77DF72A6DE0310058CDF8 /* Habit+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Habit+CoreDataClass.swift"; sourceTree = "<group>"; };
 		7EE77DF82A6DE0310058CDF8 /* Habit+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Habit+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		7EF1E2B12A6EDE9C00DE3517 /* HabitRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabitRowView.swift; sourceTree = "<group>"; };
+		7EF7DCC62A8D15C7007AF16C /* Weekday.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weekday.swift; sourceTree = "<group>"; };
 		7EF9C85A2A7B1DFC006E5130 /* CalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -217,6 +219,7 @@
 				7EA6C3EE2A7295C100DA4C41 /* Week.swift */,
 				7EA6C3EC2A72950C00DA4C41 /* MultiWeekView.swift */,
 				7EAAB24C2A8BD9C00075F9EB /* WeekView.swift */,
+				7EF7DCC62A8D15C7007AF16C /* Weekday.swift */,
 			);
 			path = Calendars;
 			sourceTree = "<group>";
@@ -312,6 +315,7 @@
 				7E697DD42A843B84000EC5D8 /* HabitView.swift in Sources */,
 				7E83225D2A72F3E200042486 /* HabitListView.swift in Sources */,
 				7ECD695B2A7D31930096AF19 /* CalendarGridView.swift in Sources */,
+				7EF7DCC72A8D15C7007AF16C /* Weekday.swift in Sources */,
 				7E697DD22A843B74000EC5D8 /* AddHabitView.swift in Sources */,
 				7E93174F2A7D84160074E210 /* HapticManager.swift in Sources */,
 				7EE77DEA2A6DDBC90058CDF8 /* Habiscus.xcdatamodeld in Sources */,

--- a/Habiscus/Calendars/CalendarGridView.swift
+++ b/Habiscus/Calendars/CalendarGridView.swift
@@ -66,6 +66,8 @@ struct CalendarGridView: View {
                 .onTapGesture {
                     date = day.date
                 }
+                .opacity(day.inWeekdays ? 1 : 0.33)
+                .disabled(!day.inWeekdays)
             }
         }
     }
@@ -85,12 +87,11 @@ struct CalendarGridView_Previews: PreviewProvider {
         count.id = UUID()
         count.createdAt = countDate
         count.date = Date()
-        //count.progress = progress
-        //progress.addToCounts(count)
         progress.isSkipped = true
         habit.name = "Test"
         habit.createdAt = countDate
         habit.addToProgress(progress)
+        habit.weekdays = "Monday, Wednesday, Friday"
         habit.goal = 2
         habit.goalFrequency = 1
         return CalendarGridView(date: .constant(Date()), month: CalendarMonth(date: Date(), habit: habit), size: 36, color: .pink)

--- a/Habiscus/Calendars/Date.swift
+++ b/Habiscus/Calendars/Date.swift
@@ -27,6 +27,32 @@ extension Date {
         abs(daysBetween(date) ?? 0) > 1
     }
     
+    func validDaysBetween(_ stopDate: Date, in weekdays: [Weekday], direction: Calendar.SearchDirection = .backward) -> Int? {
+        var result: [Date] = []
+        let weekdayNumbers = weekdays.compactMap {
+            if let num = Weekday.allValues.firstIndex(of: $0) {
+                return Int(num + 1)
+            } else {
+                return nil
+            }
+        }.sorted()
+        let prevDay = Calendar.current.date(byAdding: .day, value: -1, to: self)!
+        
+        Calendar.current.enumerateDates(startingAfter: prevDay, matching: DateComponents(hour: 0, minute: 0, second: 0), matchingPolicy: .nextTime) { (date, _, stop) in
+            if let date = date,
+               date <= stopDate {
+                let weekday = Calendar.current.component(.weekday, from: date)
+                if weekdayNumbers.contains(weekday) {
+                    result.append(date)
+                }
+            } else {
+                stop = true
+            }
+        }
+        
+        return result.count
+    }
+    
     func startOfMonth() -> Date {
         return Calendar.current.date(from: Calendar.current.dateComponents([.year, .month], from: Calendar.current.startOfDay(for: self)))!
     }

--- a/Habiscus/Calendars/MultiWeekView.swift
+++ b/Habiscus/Calendars/MultiWeekView.swift
@@ -1,0 +1,85 @@
+//
+//  WeekView.swift
+//  Habiscus
+//
+//  Created by Skylar Clemens on 7/27/23.
+//
+
+import SwiftUI
+
+struct MultiWeekView: View {
+    @Binding var selectedDate: Date
+    private var week: Week {
+        Week(initialDate: selectedDate)
+    }
+    private var allWeeks: [Week] {
+        week.getRelatedWeeks()
+    }
+    
+    @State private var currentIndex: Int = 0
+    @GestureState private var currentTranslation: CGFloat = 0
+    
+    var body: some View {
+        VStack {
+            GeometryReader { geo in
+                HStack(spacing: 0) {
+                    ForEach(allWeeks.indices, id: \.self) { index in
+                        HStack(spacing: 8) {
+                            ForEach(allWeeks[index].currentWeek, id: \.self) { weekday in
+                                let isSelectedDay = Calendar.current.isDate(selectedDate, inSameDayAs: weekday)
+                                VStack {
+                                    Text(weekday, format: .dateTime.weekday())
+                                        .font(.caption)
+                                    Text(weekday, format: .dateTime.day())
+                                        .bold()
+                                }
+                                .foregroundColor(isSelectedDay ? .white : .primary)
+                                .padding(8)
+                                .frame(width: 42)
+                                .background(isSelectedDay ? .pink : Color(UIColor.systemFill))
+                                .opacity(isSelectedDay ? 1 : 0.75)
+                                .clipShape(RoundedRectangle(cornerRadius: 16))
+                                .onTapGesture {
+                                    selectedDate = weekday
+                                    currentIndex = 0
+                                }
+                            }
+                        }
+                        .frame(width: geo.size.width)
+                    }
+                }
+                .frame(width: geo.size.width)
+                .frame(maxHeight: .infinity)
+                .offset(x: geo.size.width * CGFloat(currentIndex))
+                .offset(x: currentTranslation)
+                .animation(.spring(), value: currentTranslation)
+                .gesture(
+                    DragGesture()
+                        .updating($currentTranslation) { value, state, _ in
+                            if currentIndex == 1 && value.translation.width > 0 {
+                                return
+                            } else if currentIndex == -1 && value.translation.width < 0 {
+                                return
+                            }
+                            state = value.translation.width
+                        }.onEnded { value in
+                            withAnimation(.interactiveSpring()) {
+                                if value.predictedEndTranslation.width > 0 {
+                                    currentIndex = min(currentIndex + 1, 1)
+                                } else {
+                                    currentIndex = max(currentIndex - 1, -1)
+                                }
+                            }
+                        }
+                )
+                
+            }
+        }
+    }
+}
+
+struct MultiWeekView_Previews: PreviewProvider {
+    static var previews: some View {
+        MultiWeekView(selectedDate: .constant(Date()))
+    }
+}

--- a/Habiscus/Calendars/Week.swift
+++ b/Habiscus/Calendars/Week.swift
@@ -38,8 +38,8 @@ struct Week: Hashable {
         self.initialDate = initialDate
     }
     
-    func getRelatedWeek(_ direction: RelatedWeeks) -> Week {
-        let dayValue = direction == .next ? 7 : -7
+    func getRelatedWeek(_ direction: RelatedWeeks, distance: Int = 1) -> Week {
+        let dayValue = direction == .next ? 7 * distance : -7 * distance
         let oneWeekAgo = Calendar.current.date(byAdding: .day, value: dayValue, to: self.initialDate)!
         return Week(initialDate: oneWeekAgo)
     }

--- a/Habiscus/Calendars/WeekView.swift
+++ b/Habiscus/Calendars/WeekView.swift
@@ -7,10 +7,6 @@
 
 import SwiftUI
 
-enum Weekday: String, CaseIterable {
-    case sunday, monday, tuesday, wednesday, thursday, friday, saturday
-}
-
 struct WeekView: View {
     private let weekdays: [String] = Calendar.current.weekdaySymbols
     @Binding var selectedWeekdays: Set<Weekday>

--- a/Habiscus/Calendars/WeekView.swift
+++ b/Habiscus/Calendars/WeekView.swift
@@ -13,12 +13,13 @@ enum Weekday: String, CaseIterable {
 
 struct WeekView: View {
     private let weekdays: [String] = Calendar.current.weekdaySymbols
-    @Binding var selectedWeekdays: [Weekday : Bool]
+    @Binding var selectedWeekdays: Set<Weekday>
+    @Binding var frequency: String
     
     var body: some View {
         HStack {
             ForEach(Weekday.allCases, id: \.rawValue) { weekday in
-                let isSelectedDay: Bool = selectedWeekdays[weekday] == true
+                let isSelectedDay: Bool = selectedWeekdays.contains(weekday)
                 VStack {
                     Text(weekday.rawValue.localizedCapitalized.prefix(1))
                         .font(.system(size: 16, design: .rounded))
@@ -26,12 +27,17 @@ struct WeekView: View {
                 }
                 .foregroundColor(isSelectedDay ? .white : .primary)
                 .padding(8)
-                .frame(width: 42)
+                .frame(maxWidth: .infinity)
                 .background(isSelectedDay ? .pink : Color(UIColor.systemFill))
                 .opacity(isSelectedDay ? 1 : 0.75)
                 .clipShape(RoundedRectangle(cornerRadius: 16))
                 .onTapGesture {
-                    selectedWeekdays[weekday] = !selectedWeekdays[weekday]!
+                    if selectedWeekdays.count > 1 && selectedWeekdays.contains(weekday) {
+                        selectedWeekdays.remove(weekday)
+                    } else if !selectedWeekdays.contains(weekday) {
+                        selectedWeekdays.insert(weekday)
+                    }
+                    print(selectedWeekdays)
                 }
             }
         }
@@ -40,6 +46,6 @@ struct WeekView: View {
 
 struct WeekView_Previews: PreviewProvider {
     static var previews: some View {
-        WeekView(selectedWeekdays: .constant([.sunday: true, .monday: true, .tuesday: true, .wednesday: true, .thursday: true, .friday: true, .saturday: true]))
+        WeekView(selectedWeekdays: .constant([.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]), frequency: .constant("Daily"))
     }
 }

--- a/Habiscus/Calendars/WeekView.swift
+++ b/Habiscus/Calendars/WeekView.swift
@@ -14,7 +14,6 @@ enum Weekday: String, CaseIterable {
 struct WeekView: View {
     private let weekdays: [String] = Calendar.current.weekdaySymbols
     @Binding var selectedWeekdays: Set<Weekday>
-    @Binding var frequency: String
     
     var body: some View {
         HStack {
@@ -45,6 +44,6 @@ struct WeekView: View {
 
 struct WeekView_Previews: PreviewProvider {
     static var previews: some View {
-        WeekView(selectedWeekdays: .constant([.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]), frequency: .constant("Daily"))
+        WeekView(selectedWeekdays: .constant([.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]))
     }
 }

--- a/Habiscus/Calendars/WeekView.swift
+++ b/Habiscus/Calendars/WeekView.swift
@@ -2,77 +2,37 @@
 //  WeekView.swift
 //  Habiscus
 //
-//  Created by Skylar Clemens on 7/27/23.
+//  Created by Skylar Clemens on 8/15/23.
 //
 
 import SwiftUI
 
+enum Weekday: String, CaseIterable {
+    case sunday, monday, tuesday, wednesday, thursday, friday, saturday
+}
+
 struct WeekView: View {
-    @Binding var selectedDate: Date
-    private var week: Week {
-        Week(initialDate: selectedDate)
-    }
-    private var allWeeks: [Week] {
-        week.getRelatedWeeks()
-    }
-    
-    @State private var currentIndex: Int = 0
-    @GestureState private var currentTranslation: CGFloat = 0
+    private let weekdays: [String] = Calendar.current.weekdaySymbols
+    @Binding var selectedWeekdays: [Weekday : Bool]
     
     var body: some View {
-        VStack {
-            GeometryReader { geo in
-                HStack(spacing: 0) {
-                    ForEach(allWeeks.indices, id: \.self) { index in
-                        HStack(spacing: 8) {
-                            ForEach(allWeeks[index].currentWeek, id: \.self) { weekday in
-                                let isSelectedDay = Calendar.current.isDate(selectedDate, inSameDayAs: weekday)
-                                VStack {
-                                    Text(weekday, format: .dateTime.weekday())
-                                        .font(.caption)
-                                    Text(weekday, format: .dateTime.day())
-                                        .bold()
-                                }
-                                .foregroundColor(isSelectedDay ? .white : .primary)
-                                .padding(8)
-                                .frame(width: 42)
-                                .background(isSelectedDay ? .pink : Color(UIColor.systemFill))
-                                .opacity(isSelectedDay ? 1 : 0.75)
-                                .clipShape(RoundedRectangle(cornerRadius: 16))
-                                .onTapGesture {
-                                    selectedDate = weekday
-                                    currentIndex = 0
-                                }
-                            }
-                        }
-                        .frame(width: geo.size.width)
-                    }
+        HStack {
+            ForEach(Weekday.allCases, id: \.rawValue) { weekday in
+                let isSelectedDay: Bool = selectedWeekdays[weekday] == true
+                VStack {
+                    Text(weekday.rawValue.localizedCapitalized.prefix(1))
+                        .font(.system(size: 16, design: .rounded))
+                        .fontWeight(isSelectedDay ? .bold : .regular)
                 }
-                .frame(width: geo.size.width)
-                .frame(maxHeight: .infinity)
-                .offset(x: geo.size.width * CGFloat(currentIndex))
-                .offset(x: currentTranslation)
-                .animation(.spring(), value: currentTranslation)
-                .gesture(
-                    DragGesture()
-                        .updating($currentTranslation) { value, state, _ in
-                            if currentIndex == 1 && value.translation.width > 0 {
-                                return
-                            } else if currentIndex == -1 && value.translation.width < 0 {
-                                return
-                            }
-                            state = value.translation.width
-                        }.onEnded { value in
-                            withAnimation(.interactiveSpring()) {
-                                if value.predictedEndTranslation.width > 0 {
-                                    currentIndex = min(currentIndex + 1, 1)
-                                } else {
-                                    currentIndex = max(currentIndex - 1, -1)
-                                }
-                            }
-                        }
-                )
-                
+                .foregroundColor(isSelectedDay ? .white : .primary)
+                .padding(8)
+                .frame(width: 42)
+                .background(isSelectedDay ? .pink : Color(UIColor.systemFill))
+                .opacity(isSelectedDay ? 1 : 0.75)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .onTapGesture {
+                    selectedWeekdays[weekday] = !selectedWeekdays[weekday]!
+                }
             }
         }
     }
@@ -80,6 +40,6 @@ struct WeekView: View {
 
 struct WeekView_Previews: PreviewProvider {
     static var previews: some View {
-        WeekView(selectedDate: .constant(Date()))
+        WeekView(selectedWeekdays: .constant([.sunday: true, .monday: true, .tuesday: true, .wednesday: true, .thursday: true, .friday: true, .saturday: true]))
     }
 }

--- a/Habiscus/Calendars/WeekView.swift
+++ b/Habiscus/Calendars/WeekView.swift
@@ -37,7 +37,6 @@ struct WeekView: View {
                     } else if !selectedWeekdays.contains(weekday) {
                         selectedWeekdays.insert(weekday)
                     }
-                    print(selectedWeekdays)
                 }
             }
         }

--- a/Habiscus/Calendars/Weekday.swift
+++ b/Habiscus/Calendars/Weekday.swift
@@ -1,0 +1,14 @@
+//
+//  Weekday.swift
+//  Habiscus
+//
+//  Created by Skylar Clemens on 8/16/23.
+//
+
+import Foundation
+
+public enum Weekday: String, CaseIterable {
+    case sunday, monday, tuesday, wednesday, thursday, friday, saturday
+    
+    static let allValues = [sunday, monday, tuesday, wednesday, thursday, friday, saturday]
+}

--- a/Habiscus/ContentView.swift
+++ b/Habiscus/ContentView.swift
@@ -36,7 +36,7 @@ struct ContentView: View {
                             dateSelected = Date()
                         }
                         .animation(.spring(), value: dateSelected)
-                        WeekView(selectedDate: $dateSelected)
+                        MultiWeekView(selectedDate: $dateSelected)
                             .frame(height: 60)
                             .padding(.bottom, 16)
                             .offset(y: -15)

--- a/Habiscus/ContentView.swift
+++ b/Habiscus/ContentView.swift
@@ -15,10 +15,6 @@ struct ContentView: View {
     @State private var addHabitOpen = false
     @State private var dateSelected: Date = Date()
     
-    var currentWeekday: String {
-        dateSelected.formatted(Date.FormatStyle().weekday(.wide))
-    }
-    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -45,7 +41,7 @@ struct ContentView: View {
                             .padding(.bottom, 16)
                             .offset(y: -15)
                     }
-                    HabitListView(dateSelected: $dateSelected, addHabitOpen: $addHabitOpen, weekdayFilter: currentWeekday)
+                    HabitListView(dateSelected: $dateSelected, addHabitOpen: $addHabitOpen, weekdayFilter: dateSelected.currentWeekdayString)
                 }
                 .toolbar {
                     Button {

--- a/Habiscus/ContentView.swift
+++ b/Habiscus/ContentView.swift
@@ -15,6 +15,10 @@ struct ContentView: View {
     @State private var addHabitOpen = false
     @State private var dateSelected: Date = Date()
     
+    var currentWeekday: String {
+        dateSelected.formatted(Date.FormatStyle().weekday(.wide))
+    }
+    
     var body: some View {
         NavigationStack {
             ZStack {
@@ -41,7 +45,7 @@ struct ContentView: View {
                             .padding(.bottom, 16)
                             .offset(y: -15)
                     }
-                    HabitListView(dateSelected: $dateSelected, addHabitOpen: $addHabitOpen)
+                    HabitListView(dateSelected: $dateSelected, addHabitOpen: $addHabitOpen, weekdayFilter: currentWeekday)
                 }
                 .toolbar {
                     Button {

--- a/Habiscus/DataManagers/HabitManager.swift
+++ b/Habiscus/DataManagers/HabitManager.swift
@@ -25,47 +25,39 @@ struct HabitManager {
     
     // Makes sure the date is today or earlier
     // Creates a new count and adds it to progress
-    func addNewCount(progress: Progress, date: Date, habit: Habit? = nil) -> Bool {
-        guard !date.isAfter(Date()) else {
-            return false
-        }
+    func addNewCount(progress: Progress, date: Date, habit: Habit? = nil, amount: Int? = 1) {
+        guard !date.isAfter(Date()) else { return }
         
         let newCount = Count(context: moc)
         newCount.id = UUID()
         newCount.createdAt = Date()
         newCount.date = Calendar.current.isDateInToday(date) ? Date() : date
         newCount.progress = progress
+        newCount.amount = Int16(amount ?? 1)
         progress.addToCounts(newCount)
         
         updateProgress(progress)
         try? moc.save()
-        
-        var progressJustCompleted = false
-        if let habit = habit {
-            progressJustCompleted = progress.countsArray.count == habit.goalNumber
-        }
-        
-        return progressJustCompleted
     }
     
     // Makes sure the date is today or earlier
     // Creates a new Progress entity and adds a new count
     // Returns whether the progress was just completed or not
-    func addNewProgress(habit: Habit? = nil, date: Date, skip: Bool = false) -> Bool {
-        guard !date.isAfter(Date()) else { return false }
-        guard let habit = getHabit(habit) else { return false }
+    func addNewProgress(habit: Habit? = nil, date: Date, skip: Bool = false, amount: Int? = 1) {
+        guard !date.isAfter(Date()) else { return }
+        guard let habit = getHabit(habit) else { return }
         let newProgress = Progress(context: moc)
         newProgress.id = UUID()
         newProgress.date = date
         newProgress.lastUpdated = Date()
-        newProgress.isCompleted = habit.goalNumber == 1
+        newProgress.isCompleted = amount! >= habit.goalNumber
         newProgress.isSkipped = skip
         newProgress.habit = habit
         habit.addToProgress(newProgress)
         
-        if skip { return false }
+        if skip { return }
         
-        return addNewCount(progress: newProgress, date: date, habit: habit)
+        addNewCount(progress: newProgress, date: date, habit: habit, amount: amount)
     }
     
     func addNewSkippedProgress(habit: Habit? = nil, date: Date) {

--- a/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
+++ b/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22G74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Count" representedClassName="Count" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>

--- a/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
+++ b/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
@@ -15,6 +15,7 @@
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isArchived" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="metric" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <relationship name="progress" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Progress" inverseName="habit" inverseEntity="Progress"/>
     </entity>

--- a/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
+++ b/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
@@ -17,6 +17,7 @@
         <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="metric" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="weekdays" optional="YES" attributeType="String"/>
         <relationship name="progress" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Progress" inverseName="habit" inverseEntity="Progress"/>
     </entity>
     <entity name="Progress" representedClassName="Progress" syncable="YES">

--- a/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
+++ b/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
@@ -10,6 +10,7 @@
     <entity name="Habit" representedClassName="Habit" syncable="YES">
         <attribute name="color" optional="YES" attributeType="String"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="goal" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="goalFrequency" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="icon" optional="YES" attributeType="String"/>
@@ -18,6 +19,7 @@
         <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="metric" optional="YES" attributeType="String"/>
         <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="weekdays" optional="YES" attributeType="String"/>
         <relationship name="progress" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Progress" inverseName="habit" inverseEntity="Progress"/>
     </entity>

--- a/Habiscus/Views/Components/AddCountView.swift
+++ b/Habiscus/Views/Components/AddCountView.swift
@@ -1,0 +1,79 @@
+//
+//  AddCountView.swift
+//  Habiscus
+//
+//  Created by Skylar Clemens on 8/15/23.
+//
+
+import SwiftUI
+
+struct AddCountView: View {
+    @Environment(\.managedObjectContext) var moc
+    @State private var countAmount: Int = 1
+    @State private var showAddCountAlert: Bool = false
+    @ObservedObject var habit: Habit
+    var progress: Progress?
+    @Binding var date: Date
+    
+    private var habitManager: HabitManager {
+        HabitManager(context: moc, habit: habit)
+    }
+    
+    var body: some View {
+        Button {
+            showAddCountAlert.toggle()
+        } label: {
+            Image(systemName: "plus")
+                .bold()
+                .foregroundColor(.white)
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(.white.opacity(0.25))
+        )
+        .buttonStyle(.plain)
+        .alert("Enter \(habit.goalMetric) amount", isPresented: $showAddCountAlert) {
+            TextField("Enter count amount", value: $countAmount, format: .number)
+                .keyboardType(.numberPad)
+            Button("Cancel", role: .cancel) { }
+            Button("OK") {
+                if let progress = progress { habitManager.addNewCount(progress: progress, date: date, habit: habit, amount: countAmount)
+                } else {
+                    habitManager.addNewProgress(date: date, amount: countAmount)
+                }
+                
+                simpleSuccess()
+            }
+        }
+    }
+    
+    func simpleSuccess() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+    }
+}
+
+struct AddCountView_Previews: PreviewProvider {
+    static var dataController = DataController()
+    static var moc = dataController.container.viewContext
+    static var habitManager = HabitManager(context: moc)
+    static var previews: some View {
+        let habit = Habit(context: moc)
+        let count = Count(context: moc)
+        let progress = Progress(context: moc)
+        progress.date = Date.now
+        progress.isCompleted = false
+        count.createdAt = Date.now
+        count.progress = progress
+        habit.name = "Test"
+        habit.icon = "🤩"
+        habit.createdAt = Date.now
+        progress.addToCounts(count)
+        habit.addToProgress(progress)
+        habit.goal = 1
+        habit.goalFrequency = 1
+        
+        return AddCountView(habit: habit, date: .constant(Date.now))
+    }
+}

--- a/Habiscus/Views/Components/AddCountView.swift
+++ b/Habiscus/Views/Components/AddCountView.swift
@@ -14,10 +14,7 @@ struct AddCountView: View {
     @ObservedObject var habit: Habit
     var progress: Progress?
     @Binding var date: Date
-    
-    private var habitManager: HabitManager {
-        HabitManager(context: moc, habit: habit)
-    }
+    var habitManager: HabitManager
     
     var body: some View {
         Button {
@@ -74,6 +71,6 @@ struct AddCountView_Previews: PreviewProvider {
         habit.goal = 1
         habit.goalFrequency = 1
         
-        return AddCountView(habit: habit, date: .constant(Date.now))
+        return AddCountView(habit: habit, date: .constant(Date.now), habitManager: HabitManager(context: moc))
     }
 }

--- a/Habiscus/Views/HabitList/HabitListView.swift
+++ b/Habiscus/Views/HabitList/HabitListView.swift
@@ -34,9 +34,15 @@ struct HabitListView: View {
     @Binding var dateSelected: Date
     @Binding var addHabitOpen: Bool
 
-    @FetchRequest(sortDescriptors: [
-        SortDescriptor(\.createdAt, order: .reverse)
-    ], predicate: NSPredicate(format: "isArchived == NO"), animation: .default) var habits: FetchedResults<Habit>
+    @FetchRequest var habits: FetchedResults<Habit>
+    
+    init(dateSelected: Binding<Date>, addHabitOpen: Binding<Bool>, weekdayFilter: String) {
+        self._dateSelected = dateSelected
+        self._addHabitOpen = addHabitOpen
+        self._habits = FetchRequest<Habit>(sortDescriptors: [
+            SortDescriptor(\.createdAt, order: .reverse)
+        ], predicate: NSPredicate(format: "(isArchived == NO) AND weekdays CONTAINS[c] %@", weekdayFilter), animation: .default)
+    }
     
     var openHabits: [Habit] {
         habits.filter {
@@ -120,7 +126,7 @@ struct HabitListView: View {
                         }
                     } header: {
                         Text("Skipped")
-                            .font(.system(.title2 , design: .rounded))
+                            .font(.system(.title2, design: .rounded))
                             .textCase(nil)
                             .foregroundColor(.secondary)
                     }
@@ -138,7 +144,7 @@ struct HabitListView: View {
 struct HabitListView_Previews: PreviewProvider {
     static var dataController = DataController()
     static var previews: some View {
-        HabitListView(dateSelected: .constant(Date()), addHabitOpen: .constant(false))
+        HabitListView(dateSelected: .constant(Date()), addHabitOpen: .constant(false), weekdayFilter: "Monday")
             .environment(\.managedObjectContext, dataController.container.viewContext)
     }
 }

--- a/Habiscus/Views/HabitList/HabitListView.swift
+++ b/Habiscus/Views/HabitList/HabitListView.swift
@@ -39,9 +39,12 @@ struct HabitListView: View {
     init(dateSelected: Binding<Date>, addHabitOpen: Binding<Bool>, weekdayFilter: String) {
         self._dateSelected = dateSelected
         self._addHabitOpen = addHabitOpen
+        let isArchivedPredicate = NSPredicate(format: "isArchived == NO")
+        let containsWeekdaysPredicate = NSPredicate(format: "weekdays CONTAINS[c] %@", weekdayFilter)
+        let afterStartDatePredicate = NSPredicate(format: "startDate == nil OR startDate <= %@", dateSelected.wrappedValue as NSDate)
         self._habits = FetchRequest<Habit>(sortDescriptors: [
             SortDescriptor(\.createdAt, order: .reverse)
-        ], predicate: NSPredicate(format: "(isArchived == NO) AND weekdays CONTAINS[c] %@", weekdayFilter), animation: .default)
+        ], predicate: NSCompoundPredicate(type: .and, subpredicates: [isArchivedPredicate, containsWeekdaysPredicate, afterStartDatePredicate]), animation: .default)
     }
     
     var openHabits: [Habit] {

--- a/Habiscus/Views/HabitList/HabitRowView.swift
+++ b/Habiscus/Views/HabitList/HabitRowView.swift
@@ -67,7 +67,7 @@ struct HabitRowView: View {
                     }
                 }
                 Spacer()
-                AddCountView(habit: habit, progress: progress, date: $date)
+                AddCountView(habit: habit, progress: progress, date: $date, habitManager: habitManager)
             }
             .padding()
         }
@@ -79,10 +79,6 @@ struct HabitRowView: View {
         .onAppear {
             withAnimation(.spring(response: 1.5, dampingFraction: 1.5)) {
                 animated = true
-            }
-            if let progress = progress {
-                print("\(habit.wrappedName): \(progress.totalCount)")
-                print(habit.weekdays ?? "")
             }
         }
         .contextMenu {
@@ -141,6 +137,7 @@ struct HabitRowView_Previews: PreviewProvider {
         count.progress = progress
         habit.name = "Test"
         habit.icon = "🤩"
+        habit.weekdays = "Monday, Wednesday, Friday"
         habit.createdAt = Date.now
         progress.addToCounts(count)
         habit.addToProgress(progress)

--- a/Habiscus/Views/HabitList/HabitRowView.swift
+++ b/Habiscus/Views/HabitList/HabitRowView.swift
@@ -82,6 +82,7 @@ struct HabitRowView: View {
             }
             if let progress = progress {
                 print("\(habit.wrappedName): \(progress.totalCount)")
+                print(habit.weekdays ?? "")
             }
         }
         .contextMenu {

--- a/Habiscus/Views/HabitList/HabitRowView.swift
+++ b/Habiscus/Views/HabitList/HabitRowView.swift
@@ -15,9 +15,6 @@ struct HabitRowView: View {
     @State private var animated: Bool = false
     @Binding var date: Date
     
-    @State private var showAddCountAlert: Bool = false
-    @State private var countAmount: Int = 1
-    
     init(habit: Habit, date: Binding<Date>, progress: Progress? = nil) {
         self.habit = habit
         self._date = date
@@ -70,32 +67,7 @@ struct HabitRowView: View {
                     }
                 }
                 Spacer()
-                Button {
-                    showAddCountAlert.toggle()
-                } label: {
-                    Image(systemName: "plus")
-                        .bold()
-                        .foregroundColor(.white)
-                }
-                .padding(10)
-                .background(
-                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                        .fill(.white.opacity(0.25))
-                )
-                .buttonStyle(.plain)
-                .alert("Enter \(habit.goalMetric) amount", isPresented: $showAddCountAlert) {
-                    TextField("Enter count amount", value: $countAmount, format: .number)
-                        .keyboardType(.numberPad)
-                    Button("Cancel", role: .cancel) { }
-                    Button("OK") {
-                        if let progress = progress { habitManager.addNewCount(progress: progress, date: date, habit: habit, amount: countAmount)
-                        } else {
-                            habitManager.addNewProgress(date: date, amount: countAmount)
-                        }
-                        
-                        simpleSuccess()
-                    }
-                }
+                AddCountView(habit: habit, progress: progress, date: $date)
             }
             .padding()
         }
@@ -152,11 +124,6 @@ struct HabitRowView: View {
                 }
             }
         }
-    }
-    
-    func simpleSuccess() {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(.success)
     }
 }
 

--- a/Habiscus/Views/HabitView/AddHabitView.swift
+++ b/Habiscus/Views/HabitView/AddHabitView.swift
@@ -123,7 +123,7 @@ struct AddHabitView: View {
                             .padding(.horizontal)
                             .background(
                                 RoundedRectangle(cornerRadius: 10)
-                                    .fill(.background)
+                                    .fill(Color(UIColor.secondarySystemGroupedBackground))
                             )
                             .submitLabel(.done)
                     }
@@ -197,7 +197,7 @@ struct AddHabitView: View {
                             .padding(.horizontal)
                             .background(
                                 RoundedRectangle(cornerRadius: 10)
-                                    .fill(.background)
+                                    .fill(Color(UIColor.secondarySystemGroupedBackground))
                             )
                             .padding(4)
                             .frame(maxWidth: 100)
@@ -207,7 +207,7 @@ struct AddHabitView: View {
                             .padding(.horizontal)
                             .background(
                                 RoundedRectangle(cornerRadius: 10)
-                                    .fill(.background)
+                                    .fill(Color(UIColor.secondarySystemGroupedBackground))
                             )
                             .submitLabel(.done)
                         Text("per \(goalRepeat == "Daily" ? "day" : "week")")
@@ -243,8 +243,6 @@ struct AddHabitView: View {
                         newHabit.goalFrequency = Int16(goalRepeat == "Daily" ? 1 : 7)
                         try? moc.save()
                         setReminderNotification(id: newHabit.id!)
-                        
-                        print(goalCount)
                         
                         dismiss()
                     }

--- a/Habiscus/Views/HabitView/AddHabitView.swift
+++ b/Habiscus/Views/HabitView/AddHabitView.swift
@@ -91,6 +91,9 @@ enum Day: String, CaseIterable {
 struct AddHabitView: View {
     @Environment(\.managedObjectContext) var moc
     @Environment(\.dismiss) var dismiss
+    enum FocusedField: Hashable {
+        case goalCountField
+    }
     
     @State private var name: String = ""
     @State private var color: String = "pink"
@@ -106,15 +109,26 @@ struct AddHabitView: View {
     @State private var goalWeekdays: Set<Weekday> = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
     @State var openEmojiPicker = false
     @State var selectedEmoji: Emoji? = nil
+
+    
+    @FocusState private var focusedInput: FocusedField?
     
     var body: some View {
         NavigationStack {
             Form {
                 Section("Name") {
-                    TextField("Meditate, Drink water, etc.", text: $name)
-                        .padding()
-                        .listRowInsets(EdgeInsets())
-                        .submitLabel(.done)
+                    VStack {
+                        TextField("Meditate, Drink water, etc.", text: $name)
+                            .padding(.vertical, 10)
+                            .padding(.horizontal)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(.background)
+                            )
+                            .submitLabel(.done)
+                    }
+                    .listRowBackground(Color(UIColor.systemGroupedBackground))
+                    .listRowInsets(EdgeInsets())
                 }
                 Section("Icon and Color") {
                     HStack(alignment: .center) {
@@ -175,15 +189,32 @@ struct AddHabitView: View {
                 }
                 
                 Section("Goal") {
-                    Stepper("\(goalCount)", value: $goalCount, in: 1...1000)
                     HStack {
+                        TextField("count", value: $goalCount, format: .number)
+                            .keyboardType(.numberPad)
+                            .focused($focusedInput, equals: .goalCountField)
+                            .padding(.vertical, 10)
+                            .padding(.horizontal)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(.background)
+                            )
+                            .padding(4)
+                            .frame(maxWidth: 100)
                         TextField("time(s)", text: $metric)
-                            .textFieldStyle(.roundedBorder)
+                            .padding(.vertical, 10)
+                            .padding(.horizontal)
+                            .background(
+                                RoundedRectangle(cornerRadius: 10)
+                                    .fill(.background)
+                            )
                             .submitLabel(.done)
                         Text("per \(goalRepeat == "Daily" ? "day" : "week")")
                             .font(.callout)
                             .foregroundColor(.secondary)
                     }
+                    .listRowBackground(Color(UIColor.systemGroupedBackground))
+                    .listRowInsets(EdgeInsets())
                 }
                 .listRowSeparator(.hidden)
                 
@@ -219,6 +250,14 @@ struct AddHabitView: View {
                 ToolbarItem(placement: .navigationBarLeading) {
                     Button("Cancel") {
                         dismiss()
+                    }
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    if focusedInput == .goalCountField {
+                        Spacer()
+                        Button("Done") {
+                            focusedInput = nil
+                        }
                     }
                 }
             }
@@ -290,6 +329,8 @@ struct AddHabitView: View {
 
 struct AddHabitView_Previews: PreviewProvider {
     static var previews: some View {
-        AddHabitView()
+        ZStack {
+            AddHabitView()
+        }
     }
 }

--- a/Habiscus/Views/HabitView/AddHabitView.swift
+++ b/Habiscus/Views/HabitView/AddHabitView.swift
@@ -88,6 +88,7 @@ struct AddHabitView: View {
     let goalRepeatOptions = ["Daily", "Weekly"]
     @State private var goalRepeat: String = "Daily"
     @State private var goalCount: Int = 1
+    @State private var metric: String = ""
     @State var openEmojiPicker = false
     @State var selectedEmoji: Emoji? = nil
     
@@ -102,6 +103,7 @@ struct AddHabitView: View {
                                 .fill(Color(UIColor.secondarySystemGroupedBackground))
                         )
                         .listRowInsets(EdgeInsets())
+                        .submitLabel(.done)
                 }
                 .listRowBackground(Color(UIColor.systemGroupedBackground))
                 Section("Icon and Color") {
@@ -143,7 +145,13 @@ struct AddHabitView: View {
                             }
                         }
                         .pickerStyle(.segmented)
-                        Stepper("\(goalCount) \(goalCount > 1 ? "times" : "time")", value: $goalCount, in: 1...1000)
+                        
+                        
+                        
+                        Stepper("\(goalCount)", value: $goalCount, in: 1...1000)
+                        TextField("Time(s)", text: $metric)
+                            .textFieldStyle(.roundedBorder)
+                            .submitLabel(.done)
                     }
                     
                 }

--- a/Habiscus/Views/HabitView/AddHabitView.swift
+++ b/Habiscus/Views/HabitView/AddHabitView.swift
@@ -109,7 +109,6 @@ struct AddHabitView: View {
     @State private var goalWeekdays: Set<Weekday> = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
     @State var openEmojiPicker = false
     @State var selectedEmoji: Emoji? = nil
-
     
     @FocusState private var focusedInput: FocusedField?
     
@@ -119,6 +118,7 @@ struct AddHabitView: View {
                 Section("Name") {
                     VStack {
                         TextField("Meditate, Drink water, etc.", text: $name)
+                            .textInputAutocapitalization(.never)
                             .padding(.vertical, 10)
                             .padding(.horizontal)
                             .background(
@@ -171,7 +171,7 @@ struct AddHabitView: View {
                         .pickerStyle(.segmented)
                         VStack {
                             if goalRepeat == "Daily" {
-                                WeekView(selectedWeekdays: $goalWeekdays, frequency: $goalRepeat)
+                                WeekView(selectedWeekdays: $goalWeekdays)
                             } else {
                                 Text("Goal will be reset weekly")
                                     .foregroundColor(.secondary)
@@ -202,6 +202,7 @@ struct AddHabitView: View {
                             .padding(4)
                             .frame(maxWidth: 100)
                         TextField("time(s)", text: $metric)
+                            .textInputAutocapitalization(.never)
                             .padding(.vertical, 10)
                             .padding(.horizontal)
                             .background(
@@ -235,13 +236,15 @@ struct AddHabitView: View {
                         newHabit.color = color
                         newHabit.icon = selectedEmoji?.char
                         newHabit.createdAt = Date.now
-                        newHabit.metric = metric.isEmpty ? "count" : metric
                         newHabit.weekdays = daysSelected
                         newHabit.goal = Int16(goalCount)
+                        newHabit.metric = metric.isEmpty ? "count" : metric
                         newHabit.isArchived = false
                         newHabit.goalFrequency = Int16(goalRepeat == "Daily" ? 1 : 7)
                         try? moc.save()
                         setReminderNotification(id: newHabit.id!)
+                        
+                        print(goalCount)
                         
                         dismiss()
                     }

--- a/Habiscus/Views/HabitView/HabitView.swift
+++ b/Habiscus/Views/HabitView/HabitView.swift
@@ -71,25 +71,7 @@ struct HabitView: View {
                                     }
                                 }
                                 Spacer()
-                                Button {
-                                    if let progress = progress {
-                                        habitManager.addNewCount(progress: progress, date: date, habit: habit)
-                                    } else {
-                                        habitManager.addNewProgress(date: date)
-                                    }
-                                    
-                                    simpleSuccess()
-                                } label: {
-                                    Image(systemName: "plus")
-                                        .bold()
-                                        .foregroundColor(.white)
-                                }
-                                .padding(10)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                        .fill(.white.opacity(0.25))
-                                )
-                                .buttonStyle(.plain)
+                                AddCountView(habit: habit, progress: progress, date: $date)
                             }
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Habiscus/Views/HabitView/HabitView.swift
+++ b/Habiscus/Views/HabitView/HabitView.swift
@@ -71,7 +71,7 @@ struct HabitView: View {
                                     }
                                 }
                                 Spacer()
-                                AddCountView(habit: habit, progress: progress, date: $date)
+                                AddCountView(habit: habit, progress: progress, date: $date, habitManager: habitManager)
                             }
                         }
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -177,6 +177,7 @@ struct HabitView_Previews: PreviewProvider {
         progress.isSkipped = false
         habit.name = "Test"
         habit.icon = "🤩"
+        habit.weekdays = "Monday, Wednesday, Friday"
         habit.createdAt = Date.now
         habit.addToProgress(progress)
         habit.goal = 1

--- a/Habiscus/Views/HabitView/HabitView.swift
+++ b/Habiscus/Views/HabitView/HabitView.swift
@@ -64,7 +64,7 @@ struct HabitView: View {
                                         .bold()
                                         .foregroundColor(.white)
                                     if habit.icon != nil {
-                                        Text("\(progress?.totalCount ?? 0) / \(habit.goalFrequencyNumber)")
+                                        Text("\(progress?.totalCount ?? 0) / \(habit.goalNumber) \(habit.goalMetric)")
                                             .font(.system(.callout, design: .rounded))
                                             .bold()
                                             .foregroundColor(.white.opacity(0.75))
@@ -72,20 +72,13 @@ struct HabitView: View {
                                 }
                                 Spacer()
                                 Button {
-                                    var wasProgressJustCompleted = false
-                                    
                                     if let progress = progress {
-                                        wasProgressJustCompleted = habitManager.addNewCount(progress: progress, date: date, habit: habit)
+                                        habitManager.addNewCount(progress: progress, date: date, habit: habit)
                                     } else {
-                                        wasProgressJustCompleted = habitManager.addNewProgress(date: date)
+                                        habitManager.addNewProgress(date: date)
                                     }
                                     
-                                    if wasProgressJustCompleted {
-                                        HapticManager.instance.completionSuccess()
-                                        SoundManager.instance.playCompleteSound(sound: .complete)
-                                    } else {
-                                        simpleSuccess()
-                                    }
+                                    simpleSuccess()
                                 } label: {
                                     Image(systemName: "plus")
                                         .bold()

--- a/Habiscus/Views/HabitView/StatisticsView.swift
+++ b/Habiscus/Views/HabitView/StatisticsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct StatisticsView: View {
-    var habit: Habit
+    @ObservedObject var habit: Habit
     
     private var currentStreak: Int {
         return habit.getCurrentStreak()

--- a/Habiscus/Views/ProgressBars/GoalCounterView.swift
+++ b/Habiscus/Views/ProgressBars/GoalCounterView.swift
@@ -14,14 +14,14 @@ struct GoalCounterView: View {
     @Binding var date: Date
     var showIcon: Bool = false
     
-    private var goalCompletion: Double {
-        Double(currentGoalCount) / Double(habit.goalNumber)
-    }
     private var currentGoalCount: Int {
         if let progress = habit.findProgress(from: date) {
-            return progress.countsArray.count
+            return progress.totalCount
         }
         return 0
+    }
+    private var goalCompletion: Double {
+        Double(currentGoalCount) / Double(habit.goalNumber)
     }
     
     var body: some View {

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -18,6 +18,8 @@ extension Habit {
 
     @NSManaged public var color: String?
     @NSManaged public var createdAt: Date?
+    @NSManaged public var startDate: Date?
+    @NSManaged public var endDate: Date?
     @NSManaged public var goal: Int16
     @NSManaged public var goalFrequency: Int16
     @NSManaged public var metric: String?

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -21,6 +21,7 @@ extension Habit {
     @NSManaged public var goal: Int16
     @NSManaged public var goalFrequency: Int16
     @NSManaged public var metric: String?
+    @NSManaged public var weekdays: String?
     @NSManaged public var id: UUID?
     @NSManaged public var isArchived: Bool
     @NSManaged public var lastUpdated: Date?

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -71,7 +71,7 @@ extension Habit {
     //Filter for progress that is not skipped
     public var activeProgressArray: [Progress] {
         progressArray.filter {
-            !$0.isSkipped && !$0.countsArray.isEmpty
+            !$0.isSkipped && $0.totalCount > 0 && weekdaysArray.contains($0.weekday!)
         }
     }
 
@@ -139,13 +139,14 @@ extension Habit {
     // Divides total completed progress count over number of days since each day has one progress object
     // Returns percentage
     public var successPercentage: Double {
-        let daysSinceCreated = abs(self.createdDate.daysBetween(Date()) ?? 0)
-        let daysSinceFirstProgress = abs(self.activeProgressArray.first?.wrappedDate.daysBetween(Date()) ?? 0)
-        let progressDays = max(daysSinceCreated, daysSinceFirstProgress)
+        let daysSinceCreated = abs(self.createdDate.validDaysBetween(Date(), in: self.weekdaysArray) ?? 0)
+        let daysSinceStarted = abs(self.startDate?.validDaysBetween(Date(), in: self.weekdaysArray) ?? daysSinceCreated)
+        let daysSinceFirstProgress = abs(self.activeProgressArray.first?.wrappedDate.validDaysBetween(Date(), in: self.weekdaysArray) ?? 0)
+        let progressDays = max(daysSinceStarted, daysSinceFirstProgress)
         
-        let completedProgress = activeProgressArray.filter { $0.isCompleted }.count
+        let completedProgress = progressArray.filter { $0.isCompleted }.count
         
-        return (Double(completedProgress) / Double(progressDays + 1)) * 100
+        return (Double(completedProgress) / Double(progressDays) * 100)
     }
 
     // Starts progress array at most recent, assumed that progress is array is already sorted

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -20,6 +20,7 @@ extension Habit {
     @NSManaged public var createdAt: Date?
     @NSManaged public var goal: Int16
     @NSManaged public var goalFrequency: Int16
+    @NSManaged public var metric: String?
     @NSManaged public var id: UUID?
     @NSManaged public var isArchived: Bool
     @NSManaged public var lastUpdated: Date?
@@ -33,6 +34,10 @@ extension Habit {
 
     public var createdDate: Date {
         createdAt ?? Date()
+    }
+    
+    public var goalMetric: String {
+        metric ?? "count"
     }
     
     public var emojiIcon: String {

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -38,7 +38,7 @@ extension Habit {
     }
     
     public var goalMetric: String {
-        metric ?? "count"
+        metric ?? ""
     }
     
     public var emojiIcon: String {

--- a/Progress+CoreDataProperties.swift
+++ b/Progress+CoreDataProperties.swift
@@ -40,7 +40,7 @@ extension Progress {
     }
 
     public var totalCount: Int {
-        countsArray.count
+        countsArray.map({Int($0.amount)}).reduce(0, +)
     }
 
     public var wrappedHabit: Habit {

--- a/Progress+CoreDataProperties.swift
+++ b/Progress+CoreDataProperties.swift
@@ -27,6 +27,14 @@ extension Progress {
     public var wrappedDate: Date {
         date ?? Date.now
     }
+    
+    public var weekdayString: String {
+        wrappedDate.currentWeekdayString
+    }
+    
+    public var weekday: Weekday? {
+        Weekday(rawValue: weekdayString.localizedLowercase)
+    }
 
     public var wrappedLastUpdated: Date {
         lastUpdated ?? Date.now


### PR DESCRIPTION
- Allow user to enter a custom goal unit
- Allow user to select specific weekdays for their Habit
- Update goal metrics (streaks, success %, etc.) to account for only the weekdays the user selects
- Update calendar to show selected weekdays
- Disable calendar from going to future months
- Allow user to enter a start date and an optional end date
- Add custom goal metric/unit, weekdays, start/end dates to Add Habit view