### PR TITLE
Add CloudKit, default counts

### DIFF
--- a/Habiscus - Habit Tracker.xcodeproj/project.pbxproj
+++ b/Habiscus - Habit Tracker.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		7EB770902A8423BE00559D73 /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB7708F2A8423BE00559D73 /* IconView.swift */; };
 		7ECD695B2A7D31930096AF19 /* CalendarGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD695A2A7D31930096AF19 /* CalendarGridView.swift */; };
 		7ED93E152A7AE2B0000C41B9 /* CountGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED93E142A7AE2B0000C41B9 /* CountGridView.swift */; };
+		7EE0FCA02AFAD55A00F600D0 /* AdditionalOptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE0FC9F2AFAD55A00F600D0 /* AdditionalOptionsView.swift */; };
 		7EE16BD02A9015D1002720DC /* EditHabitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE16BCF2A9015D1002720DC /* EditHabitView.swift */; };
 		7EE5ED2F2A8E79AA007424CD /* RemindersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE5ED2E2A8E79AA007424CD /* RemindersView.swift */; };
 		7EE5ED312A8E7AC5007424CD /* ColorPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EE5ED302A8E7AC5007424CD /* ColorPickerView.swift */; };
@@ -203,6 +204,7 @@
 		7EB7708F2A8423BE00559D73 /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		7ECD695A2A7D31930096AF19 /* CalendarGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarGridView.swift; sourceTree = "<group>"; };
 		7ED93E142A7AE2B0000C41B9 /* CountGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountGridView.swift; sourceTree = "<group>"; };
+		7EE0FC9F2AFAD55A00F600D0 /* AdditionalOptionsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalOptionsView.swift; sourceTree = "<group>"; };
 		7EE16BCF2A9015D1002720DC /* EditHabitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditHabitView.swift; sourceTree = "<group>"; };
 		7EE5ED2E2A8E79AA007424CD /* RemindersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemindersView.swift; sourceTree = "<group>"; };
 		7EE5ED302A8E7AC5007424CD /* ColorPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorPickerView.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 				7EE5ED2E2A8E79AA007424CD /* RemindersView.swift */,
 				7EE5ED302A8E7AC5007424CD /* ColorPickerView.swift */,
 				7E34D8752A82EE9700A7D649 /* IconPickerView.swift */,
+				7EE0FC9F2AFAD55A00F600D0 /* AdditionalOptionsView.swift */,
 			);
 			path = EditHabit;
 			sourceTree = "<group>";
@@ -667,6 +670,7 @@
 				7EE77DFA2A6DE0310058CDF8 /* Count+CoreDataProperties.swift in Sources */,
 				7EA9FEAA2A82F6960084A843 /* Bundle-Decodable.swift in Sources */,
 				7E3AE2192A96D37900BFAC65 /* HabiscusShortcuts.swift in Sources */,
+				7EE0FCA02AFAD55A00F600D0 /* AdditionalOptionsView.swift in Sources */,
 				7EE5ED312A8E7AC5007424CD /* ColorPickerView.swift in Sources */,
 				7E1261702A7446B3009F15C9 /* Progress+CoreDataProperties.swift in Sources */,
 				7EF1E2B22A6EDE9C00DE3517 /* HabitRowView.swift in Sources */,

--- a/Habiscus - Habit Tracker.xcodeproj/project.pbxproj
+++ b/Habiscus - Habit Tracker.xcodeproj/project.pbxproj
@@ -570,7 +570,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1500;
 				TargetAttributes = {
 					7E67A79B2A6B52B9001E0C23 = {
 						CreatedOnToolsVersion = 14.3.1;
@@ -739,6 +739,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -799,6 +800,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";

--- a/Habiscus/AppIntents/HabitEntity.swift
+++ b/Habiscus/AppIntents/HabitEntity.swift
@@ -154,8 +154,8 @@ struct HabitQuery: EntityPropertyQuery {
     ) async throws -> [HabitEntity] {
         let context = DataController.shared.container.viewContext
         let request: NSFetchRequest<Habit> = Habit.fetchRequest()
-        let predicate = NSCompoundPredicate(type: mode == .and ? .and : .or, subpredicates: comparators)
-        let sortDescriptors = toSortDescriptor(sortedBy)
+        //let predicate = NSCompoundPredicate(type: mode == .and ? .and : .or, subpredicates: comparators)
+        //let sortDescriptors = toSortDescriptor(sortedBy)
         let matchingHabits = try context.fetch(request)
         return matchingHabits.map {
             HabitEntity(habit: $0)

--- a/Habiscus/Habiscus.entitlements
+++ b/Habiscus/Habiscus.entitlements
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.SkylarClemens.Habiscus</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.SkylarClemens.Habiscus</string>

--- a/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
+++ b/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
@@ -10,6 +10,7 @@
     <entity name="Habit" representedClassName="Habit" syncable="YES">
         <attribute name="color" optional="YES" attributeType="String" defaultValueString="pink"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customCount" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="defaultCount" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="frequency" optional="YES" attributeType="String" defaultValueString="daily"/>

--- a/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
+++ b/Habiscus/Habiscus.xcdatamodeld/Habiscus.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22213.2" systemVersion="22G74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="23A344" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
     <entity name="Count" representedClassName="Count" syncable="YES">
         <attribute name="amount" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -10,6 +10,7 @@
     <entity name="Habit" representedClassName="Habit" syncable="YES">
         <attribute name="color" optional="YES" attributeType="String" defaultValueString="pink"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="defaultCount" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>
         <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="frequency" optional="YES" attributeType="String" defaultValueString="daily"/>
         <attribute name="goal" optional="YES" attributeType="Integer 16" defaultValueString="1" usesScalarValueType="YES"/>

--- a/Habiscus/Info.plist
+++ b/Habiscus/Info.plist
@@ -19,6 +19,10 @@
 	<array>
 		<string>IntentIntent</string>
 	</array>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UILaunchScreen</key>
 	<dict>
 		<key>UIImageName</key>

--- a/Habiscus/Views/Components/AddCountView.swift
+++ b/Habiscus/Views/Components/AddCountView.swift
@@ -22,7 +22,11 @@ struct AddCountView: View {
     
     var body: some View {
         Button {
-            showAddCountAlert.toggle()
+            if habit.customCount {
+                showAddCountAlert.toggle()
+            } else {
+                handleAddCount(habit.defaultCountNumber)
+            }
         } label: {
             Image(systemName: "plus")
                 .bold()
@@ -40,14 +44,19 @@ struct AddCountView: View {
                 .keyboardType(.numberPad)
             Button("Cancel", role: .cancel) { }
             Button("OK") {
-                if let progress = progress { habitManager.addNewCount(progress: progress, date: date, habit: habit, amount: countAmount)
-                } else {
-                    habitManager.addNewProgress(date: date, amount: countAmount)
-                }
-                
-                HapticManager.shared.simpleSuccess()
+                handleAddCount(countAmount)
             }
         }
+    }
+    
+    func handleAddCount(_ amount: Int) {
+        if let progress = progress {
+            habitManager.addNewCount(progress: progress, date: date, habit: habit, amount: amount)
+        } else {
+            habitManager.addNewProgress(date: date, amount: countAmount)
+        }
+        
+        HapticManager.shared.simpleSuccess()
     }
 }
 

--- a/Habiscus/Views/EditHabit/AdditionalOptionsView.swift
+++ b/Habiscus/Views/EditHabit/AdditionalOptionsView.swift
@@ -1,0 +1,47 @@
+//
+//  AdditionalOptionsView.swift
+//  Habiscus - Habit Tracker
+//
+//  Created by Skylar Clemens on 11/7/23.
+//
+
+import SwiftUI
+
+struct AdditionalOptionsView: View {
+    @Binding var isCustomCount: Bool
+    @Binding var defaultCount: Int16
+    
+    var body: some View {
+        List {
+            Section {
+                Toggle("Custom count", isOn: $isCustomCount)
+            } footer: {
+                Text("When enabled, you will be prompted for a value each time progress is logged.")
+            }
+            Section {
+                Stepper("\(defaultCount)", value: $defaultCount, in: 0...32767)
+            } header: {
+                Text("Default count")
+            } footer: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Sets the default count logged when tapping the \"+\" button.")
+                    if isCustomCount {
+                        Text("Note: ")
+                            .fontWeight(.semibold) +
+                        Text("Custom count is enabled. Default count will only apply when using widgets or Shortcuts without a count value.")
+                    }
+                }
+            }
+        }
+        .navigationTitle("Additional options")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        Form {
+            AdditionalOptionsView(isCustomCount: .constant(false), defaultCount: .constant(1))
+        }
+    }
+}

--- a/Habiscus/Views/EditHabit/EditHabitView.swift
+++ b/Habiscus/Views/EditHabit/EditHabitView.swift
@@ -112,7 +112,7 @@ struct EditHabitView: View {
                 .listRowInsets(EdgeInsets())
                 
             }
-            Section("Goal") {
+            Section {
                 HStack {
                     TextField("count", value: $habit.goal, format: .number)
                         .keyboardType(.numberPad)
@@ -123,7 +123,6 @@ struct EditHabitView: View {
                             RoundedRectangle(cornerRadius: 10)
                                 .fill(Color(UIColor.secondarySystemGroupedBackground))
                         )
-                        .padding(4)
                         .frame(maxWidth: 100)
                     TextField("time(s)", text: $habit.unit ?? "")
                         .textInputAutocapitalization(.never)
@@ -140,11 +139,20 @@ struct EditHabitView: View {
                 }
                 .listRowBackground(Color(UIColor.systemGroupedBackground))
                 .listRowInsets(EdgeInsets())
+            } header: {
+                Text("Goal")
+            } footer: {
+                Text("Adjust the default count in 'Additional options'.")
             }
             .listRowSeparator(.hidden)
             DateOptions(frequency: $frequency, weekdays: $weekdays, interval: $habit.interval, startDate: $startDate, endDate: $habit.endDate)
             
             RemindersView(setReminders: $setReminders, selectedTime: $selectedTime, notifications: $notifications)
+            NavigationLink {
+                AdditionalOptionsView(isCustomCount: $habit.customCount, defaultCount: $habit.defaultCount)
+            } label: {
+                Text("Additional options")
+            }
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/HabiscusWidget/HabiscusWidgetExtension.entitlements
+++ b/HabiscusWidget/HabiscusWidgetExtension.entitlements
@@ -2,6 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.SkylarClemens.Habiscus</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.com.SkylarClemens.Habiscus</string>

--- a/HabiscusWidget/Intents/HabitIntent.swift
+++ b/HabiscusWidget/Intents/HabitIntent.swift
@@ -35,9 +35,9 @@ struct AddCountToHabit: AppIntent {
     var date: Date
     
     @Parameter(title: "Amount")
-    var amount: Int
+    var amount: Int?
     
-    init(habit: HabitEntity, date: Date, amount: Int) {
+    init(habit: HabitEntity, date: Date, amount: Int? = nil) {
         self.habit = habit
         self.date = date
         self.amount = amount
@@ -56,6 +56,10 @@ struct AddCountToHabit: AppIntent {
         }
         
         let habitManager = HabitManager(habit: selectedHabit)
+        
+        if amount == nil {
+            amount = selectedHabit.defaultCountNumber
+        }
         
         if let progress = selectedHabit.findProgress(from: date) {
             habitManager.addNewCount(progress: progress, date: date, amount: amount)

--- a/HabiscusWidget/Views/SmallHabitView.swift
+++ b/HabiscusWidget/Views/SmallHabitView.swift
@@ -17,7 +17,7 @@ struct SmallHabitView: View {
                 WidgetGoalCounter(size: 40, date: Date(), count: habit.count, goal: habit.goal, icon: habit.icon, checkmarkSize: 10)
                 Spacer()
                 if #available(iOS 17.0, *) {
-                    Button(intent: AddCountToHabit(habit: habit, date: Date(), amount: 1)) {
+                    Button(intent: AddCountToHabit(habit: habit, date: Date())) {
                         Label("Add", systemImage: "plus")
                     }
                     .labelStyle(.iconOnly)

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -32,6 +32,7 @@ extension Habit {
     @NSManaged public var unit: String?
     @NSManaged public var weekdays: String?
     @NSManaged public var defaultCount: Int16
+    @NSManaged public var customCount: Bool
     @NSManaged public var notifications: NSSet?
     @NSManaged public var progress: NSSet?
     
@@ -112,6 +113,10 @@ extension Habit {
     // TODO: Switch to Goal
     public var goalInterval: Int {
         Int(interval)
+    }
+    
+    public var defaultCountNumber: Int {
+        Int(defaultCount)
     }
     
     public var goalFrequency: String {

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -1,8 +1,8 @@
 //
 //  Habit+CoreDataProperties.swift
-//  HabiscusAppIntents
+//  Habiscus - Habit Tracker
 //
-//  Created by Skylar Clemens on 8/23/23.
+//  Created by Skylar Clemens on 11/7/23.
 //
 //
 
@@ -31,13 +31,14 @@ extension Habit {
     @NSManaged public var startDate: Date?
     @NSManaged public var unit: String?
     @NSManaged public var weekdays: String?
+    @NSManaged public var defaultCount: Int16
     @NSManaged public var notifications: NSSet?
     @NSManaged public var progress: NSSet?
-
+    
     public var wrappedName: String {
         name ?? "Unkown name"
     }
-
+    
     public var createdDate: Date {
         createdAt ?? Date()
     }
@@ -63,11 +64,11 @@ extension Habit {
     public var weekdaysArray: [Weekday] {
         weekdaysStrings.compactMap { Weekday(rawValue: $0.localizedLowercase) ?? nil }
     }
-
+    
     public var formattedCreatedDate: String {
         createdAt?.formatted(.dateTime.day().month().year()) ?? "Date not found"
     }
-
+    
     public var progressArray: [Progress] {
         let set = progress as? Set<Progress> ?? []
         return set.sorted {
@@ -95,19 +96,19 @@ extension Habit {
         }
         return nil
     }
-
+    
     public var lastUpdatedDate: Date {
         lastUpdated ?? Date()
     }
-
+    
     public var habitColor: Color {
         Color(color ?? "pink")
     }
-
+    
     public var goalNumber: Int {
         Int(goal)
     }
-
+    
     // TODO: Switch to Goal
     public var goalInterval: Int {
         Int(interval)
@@ -116,7 +117,7 @@ extension Habit {
     public var goalFrequency: String {
         frequency ?? ""
     }
-
+    
     public var allCountsArray: [Count] {
         var tempCountArray: [Count] = []
         progressArray.forEach { item in
@@ -126,23 +127,23 @@ extension Habit {
         }
         return tempCountArray
     }
-
+    
     public func findProgress(from date: Date) -> Progress? {
         if let progressObjects = self.progress?.allObjects as? [Progress],
-            let progressOnDate = progressObjects.first(where: {
-            Calendar.current.isDate($0.wrappedDate, inSameDayAs: date)
-        }) {
+           let progressOnDate = progressObjects.first(where: {
+               Calendar.current.isDate($0.wrappedDate, inSameDayAs: date)
+           }) {
             return progressOnDate
         }
         return nil
     }
-
+    
     public func lastUpdatedProgress() -> Progress {
         return self.progressArray.reduce(self.progressArray[0], {
             $0.wrappedLastUpdated > $1.wrappedLastUpdated ? $0 : $1
         })
     }
-
+    
     public func mostRecentCount(from date: Date) -> Count? {
         guard let progress = findProgress(from: date) else {
             return nil
@@ -178,7 +179,7 @@ extension Habit {
         
         return (Double(completedProgress) / Double(progressDays) * 100)
     }
-
+    
     // Starts progress array at most recent, assumed that progress is array is already sorted
     // If first progress is not completed or is more than one day from today, returns a streak of 0
     // Returns first, most recent, streak of streak array
@@ -189,14 +190,14 @@ extension Habit {
         else {
             return 0
         }
-
+        
         var streaks: [Int] = []
         if Calendar.current.isDateInToday(mostRecentProgress.wrappedDate) || (closestProgress.isCompleted) {
             streaks = calculateStreaksArray(from: progressArray.reversed(), onDays: self.weekdaysArray)
         }
         return streaks.first ?? 0
     }
-
+    
     // Adds to streak if compared dates are completed and proper length apart
     // Returns array of all streaks
     public func calculateStreaksArray(from: [Progress]? = nil, onDays daysToCheck: [Weekday]) -> [Int] {
@@ -237,12 +238,11 @@ extension Habit {
         
         return streakArray
     }
-
+    
     // Gets the highest number in the streak array
     public func getLongestStreak() -> Int {
         calculateStreaksArray(from: progressArray.reversed(), onDays: self.weekdaysArray).max() ?? 0
     }
-    
 }
 
 // MARK: Generated accessors for notifications


### PR DESCRIPTION
- Add CloudKit to project
- Sync Core Data with CloudKit
- Allow user to set a default count or enable custom count for progress
- Update widgets to use default count amount when adding progress