### PR TITLE
Add History in HabitView, fix data refresh on widget

### DIFF
--- a/Action+CoreDataProperties.swift
+++ b/Action+CoreDataProperties.swift
@@ -31,6 +31,18 @@ extension Action {
         ActionType(rawValue: type ?? "timer")!
     }
     
+    public var actionTypeString: String {
+        ActionType(rawValue: wrappedType)?.label() ?? ""
+    }
+    
+    public var wrappedType: String {
+        type ?? ""
+    }
+    
+    public var wrappedDate: Date {
+        date ?? Date()
+    }
+    
     public var timerHoursAndMintutes: (hours: Int , minutes: Int) {
         intervalToHoursAndMinutes(Int(number))
     }

--- a/Habiscus - Habit Tracker.xcodeproj/xcshareddata/xcschemes/Habiscus.xcscheme
+++ b/Habiscus - Habit Tracker.xcodeproj/xcshareddata/xcschemes/Habiscus.xcscheme
@@ -49,6 +49,24 @@
             ReferencedContainer = "container:Habiscus - Habit Tracker.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.CloudKitDebug 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.Logging.stderr 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.SQLDebug 0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.Logging.stderr 0   "
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Habiscus/AppIntents/HabitEntity.swift
+++ b/Habiscus/AppIntents/HabitEntity.swift
@@ -72,7 +72,7 @@ struct HabitEntity: AppEntity, Identifiable {
     }
     
     init(habit: Habit) {
-        self.id = habit.id!
+        self.id = habit.id ?? UUID()
         self.name = habit.wrappedName
         self.createdAt = habit.createdDate
         self.startDate = habit.startDate ?? Date()
@@ -114,7 +114,13 @@ struct HabitQuery: EntityPropertyQuery {
     }
     
     func defaultResult() async -> HabitEntity? {
-        try? await suggestedEntities().first
+        do {
+            let entity = try await suggestedEntities().first
+            return entity
+        } catch {
+            print(error.localizedDescription)
+            return nil
+        }
     }
     
     static var sortingOptions = SortingOptions {

--- a/Habiscus/DataManagers/DataController.swift
+++ b/Habiscus/DataManagers/DataController.swift
@@ -31,7 +31,6 @@ class DataController: ObservableObject {
         guard let path = container.persistentStoreDescriptions.first?.url?.path else {
             fatalError("error getting path")
         }
-        print("Core Data", path)
         
         container.loadPersistentStores { description, error in
             if let error = error {

--- a/Habiscus/DataManagers/HabitManager.swift
+++ b/Habiscus/DataManagers/HabitManager.swift
@@ -11,14 +11,21 @@ import UserNotifications
 import WidgetKit
 
 struct HabitManager {
-    private let moc = DataController.shared.container.viewContext
+    private let moc: NSManagedObjectContext
     private let managedHabit: Habit?
     
     init() {
+        self.moc = DataController.shared.container.viewContext
         self.managedHabit = nil
     }
     
     init(habit: Habit) {
+        self.moc = DataController.shared.container.viewContext
+        self.managedHabit = habit
+    }
+    
+    init(habit: Habit, context: NSManagedObjectContext) {
+        self.moc = context
         self.managedHabit = habit
     }
     
@@ -135,6 +142,7 @@ struct HabitManager {
         } catch let error {
             print(error.localizedDescription)
         }
+        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
     }
     
     func unarchiveHabit(_ habit: Habit? = nil) throws {
@@ -143,6 +151,7 @@ struct HabitManager {
         }
         habit.isArchived = false
         try? moc.save()
+        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
     }
     
     func removeHabit(_ habit: Habit? = nil) throws {
@@ -152,6 +161,7 @@ struct HabitManager {
         removeAllNotifications(habit)
         moc.delete(habit)
         try? moc.save()
+        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
     }
     
     func removeHabit(_ habit: Habit? = nil, toastManager: ToastManager) throws {
@@ -173,6 +183,7 @@ struct HabitManager {
             toastManager.showAlert = true
             HapticManager.shared.simpleError()
         }
+        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
     }
     
     func removeAllNotifications(_ habit: Habit? = nil) {

--- a/Habiscus/DataManagers/HabitsManager.swift
+++ b/Habiscus/DataManagers/HabitsManager.swift
@@ -39,7 +39,12 @@ class HabitsManager: ObservableObject {
         return []
     }
     
-    func findHabit(id: UUID) throws -> Habit {
+    func findHabit(id: UUID, refresh: Bool = false) throws -> Habit {
+        if refresh {
+            try? self.context.setQueryGenerationFrom(.current)
+            self.context.refreshAllObjects()
+        }
+        
         let request: NSFetchRequest<Habit> = Habit.fetchRequest()
         request.predicate = NSPredicate(format: "id = %@", id as CVarArg)
         request.fetchLimit = 1

--- a/Habiscus/Helpers/Navigator.swift
+++ b/Habiscus/Helpers/Navigator.swift
@@ -21,7 +21,6 @@ class Navigator: ObservableObject {
     }
     
     func handleIncomingURL(_ url: URL) {
-        print(url)
         guard url.scheme == "habiscus" else {
             return
         }

--- a/Habiscus/Views/EditHabit/EditHabitView.swift
+++ b/Habiscus/Views/EditHabit/EditHabitView.swift
@@ -206,7 +206,7 @@ struct EditHabitView: View {
                     }
                     
                     // Remove all current notifications
-                    let habitManager = HabitManager(habit: habit)
+                    let habitManager = HabitManager(habit: habit, context: childContext)
                     habitManager.removeAllNotifications()
                     // Create new notifications if toggle is set
                     if setReminders {

--- a/Habiscus/Views/HabitView/HabitView.swift
+++ b/Habiscus/Views/HabitView/HabitView.swift
@@ -30,7 +30,11 @@ struct HabitView: View {
     
     private var showEntries: Bool {
         if let progress = progress {
-            return progress.countsArray.count > 0
+            if habit.wrappedProgressMethod == .counts {
+                return progress.countsArray.count > 0
+            } else {
+                return progress.completedActionsArray.count > 0
+            }
         }
         return false
     }
@@ -139,7 +143,7 @@ struct HabitView: View {
                     }
                     .padding(.horizontal)
                     .frame(maxWidth: 500)
-                    if !habit.actionsArray.isEmpty {
+                    if habit.wrappedProgressMethod == .actions && !habit.actionsArray.isEmpty {
                         VStack(spacing: 16) {
                             ForEach(habit.actionsArray) { action in
                                 HStack {
@@ -204,21 +208,55 @@ struct HabitView: View {
                         if showEntries {
                             VStack(alignment: .leading) {
                                 Section {
-                                    ForEach(progress?.countsArray ?? []) { count in
-                                        HStack(spacing: 12) {
-                                            Text("+\(count.amount)")
-                                                .foregroundColor(.white)
-                                                .padding(8)
-                                                .background(
-                                                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                                                        .fill(habit.habitColor.opacity(0.8))
-                                                        .shadow(color: habit.habitColor.opacity(0.3), radius: 4, y: 2)
-                                                )
-                                            Text(count.createdDateString)
+                                    if habit.wrappedProgressMethod == .counts {
+                                        ForEach(progress?.countsArray ?? []) { count in
+                                            HStack(spacing: 8) {
+                                                Image(systemName: "plus.circle.fill")
+                                                    .font(.system(size: 20))
+                                                    .foregroundStyle(.white, habit.habitColor)
+                                                Group {
+                                                    Text("^[\(count.amount) \(habit.wrappedUnit)](inflect: true)")
+                                                        .fontWeight(.medium) +
+                                                    Text(" added")
+                                                }.font(.system(size: 14))
+                                            }
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 8))
+                                            .background(
+                                                Capsule()
+                                                    .fill(.secondary.opacity(0.1))
+                                            )
+                                            Text(count.wrappedCreatedDate.formatted(date: .abbreviated, time: .shortened))
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                                .padding(.leading, 36)
+                                        }
+                                    } else if let completedActions = progress?.completedActionsArray {
+                                        ForEach(completedActions) { action in
+                                            HStack(spacing: 8) {
+                                                Image(systemName: "checkmark.circle.fill")
+                                                    .font(.system(size: 20))
+                                                    .foregroundStyle(.white, habit.habitColor)
+                                                Group {
+                                                    Text("\(action.actionTypeString)")
+                                                        .fontWeight(.medium) +
+                                                    Text(" completed")
+                                                }.font(.system(size: 14))
+                                            }
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .padding(EdgeInsets(top: 4, leading: 4, bottom: 4, trailing: 8))
+                                            .background(
+                                                Capsule()
+                                                    .fill(.secondary.opacity(0.1))
+                                            )
+                                            Text(action.wrappedDate.formatted(date: .abbreviated, time: .shortened))
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                                .padding(.leading, 36)
                                         }
                                     }
                                 } header: {
-                                    Text("Entries")
+                                    Text("History")
                                         .font(.headline)
                                         .padding(.bottom, 4)
                                 }

--- a/Habiscus/Views/Previews/Previewing.swift
+++ b/Habiscus/Views/Previews/Previewing.swift
@@ -88,6 +88,7 @@ struct PreviewData {
             habit.interval = 1
             habit.frequency = "daily"
             habit.weekdays = "Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday"
+            habit.progressMethod = "actions"
             
             let timerAction = Action(context: context)
             timerAction.type = "timer"
@@ -99,6 +100,27 @@ struct PreviewData {
             emotionAction.type = "emotion"
             emotionAction.order = 1
             habit.addToActions(emotionAction)
+            
+            let progressTimerAction = Action(context: context)
+            progressTimerAction.type = "timer"
+            progressTimerAction.order = 0
+            progressTimerAction.number = 60
+            progressTimerAction.completed = true
+            progressTimerAction.date = Date()
+            progressTimerAction.progress
+            
+            let progressEmotionAction = Action(context: context)
+            progressEmotionAction.type = "emotion"
+            progressEmotionAction.order = 1
+            
+            let progress = Progress(context: context)
+            progress.id = UUID()
+            progress.date = Date()
+            progress.isCompleted = true
+            progress.isSkipped = false
+            progress.habit = habit
+            progress.addToActions(progressTimerAction)
+            progress.addToActions(progressEmotionAction)
             
             return habit
         }

--- a/HabiscusWidget/HabiscusWidget.swift
+++ b/HabiscusWidget/HabiscusWidget.swift
@@ -24,18 +24,23 @@ struct HabitIntentProvider: AppIntentTimelineProvider {
     }
     
     func snapshot(for configuration: WidgetHabitSelection, in context: Context) async -> SimpleEntry {
-        SimpleEntry.placeholder
+        let habit = try? HabitsManager.shared.findHabit(id: configuration.habit.id, refresh: true)
+        if let habit {
+            let habitEntity = HabitEntity(habit: habit)
+            return SimpleEntry(habit: habitEntity, date: .now)
+        }
+        return SimpleEntry.placeholder
     }
     
     func timeline(for configuration: WidgetHabitSelection, in context: Context) async -> Timeline<SimpleEntry> {
-        let habit = try? HabitsManager.shared.findHabit(id: configuration.habit.id)
+        let habit = try? HabitsManager.shared.findHabit(id: configuration.habit.id, refresh: true)
         var entries: [SimpleEntry] = []
         if let habit {
             let habitEntity = HabitEntity(habit: habit)
-            let entry = SimpleEntry(habit: habitEntity, date: Date())
+            let entry = SimpleEntry(habit: habitEntity, date: .now)
             entries.append(entry)
         }
-        return Timeline(entries: entries, policy: .never)
+        return Timeline(entries: entries, policy: .atEnd)
     }
 }
 
@@ -49,7 +54,7 @@ struct Provider: TimelineProvider {
             let habits = try HabitsManager.shared.getAllActiveHabits()
             if let habit = habits.first {
                 let habitEntity = HabitEntity(habit: habit)
-                let entry = SimpleEntry(habit: habitEntity, date: Date())
+                let entry = SimpleEntry(habit: habitEntity, date: .now)
                 completion(entry)
             } else {
                 throw Errors.notFound
@@ -64,7 +69,7 @@ struct Provider: TimelineProvider {
             let habits = try HabitsManager.shared.getAllActiveHabits()
             var entries: [SimpleEntry] = []
 
-            let entryDate = Date()
+            let entryDate: Date = .now
             if let habit = habits.first {
                 let habitEntity = HabitEntity(habit: habit)
                 let entry = SimpleEntry(habit: habitEntity, date: entryDate)

--- a/HabiscusWidget/Intents/HabitIntent.swift
+++ b/HabiscusWidget/Intents/HabitIntent.swift
@@ -45,8 +45,9 @@ struct AddCountToHabit: AppIntent {
     
     init() {}
     
+    @MainActor
     func perform() async throws -> some IntentResult {
-        let selectedHabit = try? HabitsManager.shared.findHabitByName(name: habit.name)
+        let selectedHabit = try? HabitsManager.shared.findHabit(id: habit.id)
         
         guard let selectedHabit = selectedHabit else {
             throw Error.notFound

--- a/Progress+CoreDataProperties.swift
+++ b/Progress+CoreDataProperties.swift
@@ -55,6 +55,12 @@ extension Progress {
         }
     }
     
+    public var completedActionsArray: [Action] {
+        actionsArray.filter { $0.completed }.sorted {
+            $0.wrappedDate < $1.wrappedDate
+        }
+    }
+    
     public var totalCount: Int {
         if habit?.wrappedProgressMethod == .counts {
             countsArray.map({Int($0.amount)}).reduce(0, +)


### PR DESCRIPTION
- Allow user to view count/action history in Habit details page
- Show up-to-date data for habit in widget
- Increment data from widget, and show
- Add new preview habits