### PR TITLE
Create Multi-habit Widget

### DIFF
--- a/Habiscus - Habit Tracker.xcodeproj/project.pbxproj
+++ b/Habiscus - Habit Tracker.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		7E34D8762A82EE9700A7D649 /* IconPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E34D8752A82EE9700A7D649 /* IconPickerView.swift */; };
 		7E34D87E2A82F47300A7D649 /* EmojiManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E34D87D2A82F47300A7D649 /* EmojiManager.swift */; };
 		7E36B7422A956F28006D4632 /* ToastManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E36B7412A956F28006D4632 /* ToastManager.swift */; };
+		7E3A74CF2B696A78009248F6 /* WidgetGoalCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3A74CE2B696A78009248F6 /* WidgetGoalCounter.swift */; };
 		7E3AE2182A96D37600BFAC65 /* HabiscusAppIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2DF2CB2A96A66900890B8E /* HabiscusAppIntents.swift */; };
 		7E3AE2192A96D37900BFAC65 /* HabiscusShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2DF2D92A96AD6C00890B8E /* HabiscusShortcuts.swift */; };
 		7E3AE21A2A96D37B00BFAC65 /* HabitEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E2DF2DB2A96ADF400890B8E /* HabitEntity.swift */; };
@@ -108,6 +109,8 @@
 		7ECD695B2A7D31930096AF19 /* CalendarGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD695A2A7D31930096AF19 /* CalendarGridView.swift */; };
 		7ECFBEA52B6826FA00935EA0 /* HabitType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFBEA42B6826FA00935EA0 /* HabitType.swift */; };
 		7ECFBEA62B6827FE00935EA0 /* HabitType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFBEA42B6826FA00935EA0 /* HabitType.swift */; };
+		7ECFBEA82B6853AC00935EA0 /* SmallMultiHabitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFBEA72B6853AC00935EA0 /* SmallMultiHabitView.swift */; };
+		7ECFBEAA2B685A8400935EA0 /* MultiHabitWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECFBEA92B685A8400935EA0 /* MultiHabitWidget.swift */; };
 		7ED649712B017D910083E80D /* TimerActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED649702B017D910083E80D /* TimerActionView.swift */; };
 		7ED649732B017D9B0083E80D /* NotesActionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED649722B017D9B0083E80D /* NotesActionView.swift */; };
 		7ED93E152A7AE2B0000C41B9 /* CountGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED93E142A7AE2B0000C41B9 /* CountGridView.swift */; };
@@ -181,6 +184,7 @@
 		7E34D8752A82EE9700A7D649 /* IconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconPickerView.swift; sourceTree = "<group>"; };
 		7E34D87D2A82F47300A7D649 /* EmojiManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmojiManager.swift; sourceTree = "<group>"; };
 		7E36B7412A956F28006D4632 /* ToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastManager.swift; sourceTree = "<group>"; };
+		7E3A74CE2B696A78009248F6 /* WidgetGoalCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetGoalCounter.swift; sourceTree = "<group>"; };
 		7E3BE9132A8C27EA008C1503 /* AddCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCountView.swift; sourceTree = "<group>"; };
 		7E4884682B62D3F30036AD37 /* FilterListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterListView.swift; sourceTree = "<group>"; };
 		7E4EAC722A93D91700EC16A5 /* Notification+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -241,6 +245,8 @@
 		7EB7708F2A8423BE00559D73 /* IconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		7ECD695A2A7D31930096AF19 /* CalendarGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarGridView.swift; sourceTree = "<group>"; };
 		7ECFBEA42B6826FA00935EA0 /* HabitType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HabitType.swift; sourceTree = "<group>"; };
+		7ECFBEA72B6853AC00935EA0 /* SmallMultiHabitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallMultiHabitView.swift; sourceTree = "<group>"; };
+		7ECFBEA92B685A8400935EA0 /* MultiHabitWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiHabitWidget.swift; sourceTree = "<group>"; };
 		7ED649702B017D910083E80D /* TimerActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimerActionView.swift; sourceTree = "<group>"; };
 		7ED649722B017D9B0083E80D /* NotesActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotesActionView.swift; sourceTree = "<group>"; };
 		7ED93E142A7AE2B0000C41B9 /* CountGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountGridView.swift; sourceTree = "<group>"; };
@@ -452,6 +458,7 @@
 				7E8460F92AF6EFA6008043B6 /* HabiscusWidgetExtension.entitlements */,
 				7E8460D62AF6E62A008043B6 /* HabiscusWidgetBundle.swift */,
 				7E8460D82AF6E62A008043B6 /* HabiscusWidget.swift */,
+				7ECFBEA92B685A8400935EA0 /* MultiHabitWidget.swift */,
 				7E8460DA2AF6E62D008043B6 /* Assets.xcassets */,
 				7E8460DC2AF6E62D008043B6 /* Info.plist */,
 			);
@@ -479,6 +486,8 @@
 			isa = PBXGroup;
 			children = (
 				7E8460E42AF6E6D6008043B6 /* SmallHabitView.swift */,
+				7ECFBEA72B6853AC00935EA0 /* SmallMultiHabitView.swift */,
+				7E3A74CE2B696A78009248F6 /* WidgetGoalCounter.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -791,6 +800,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7ECFBEAA2B685A8400935EA0 /* MultiHabitWidget.swift in Sources */,
 				7E9684532AF9900E00BBCAD4 /* HabitManager.swift in Sources */,
 				7E8460EE2AF6E8E7008043B6 /* Weekday.swift in Sources */,
 				7E8460D72AF6E62A008043B6 /* HabiscusWidgetBundle.swift in Sources */,
@@ -800,6 +810,7 @@
 				7E8460F02AF6E8FF008043B6 /* IconView.swift in Sources */,
 				7E9684542AF9902000BBCAD4 /* ToastManager.swift in Sources */,
 				7E9684552AF9902200BBCAD4 /* NotificationManager.swift in Sources */,
+				7E3A74CF2B696A78009248F6 /* WidgetGoalCounter.swift in Sources */,
 				7E96844A2AF96AC400BBCAD4 /* HabitIntent.swift in Sources */,
 				7E9684432AF9699900BBCAD4 /* HabitEntity.swift in Sources */,
 				7E96844E2AF97FA900BBCAD4 /* HabitModel.swift in Sources */,
@@ -810,6 +821,7 @@
 				7E8460EF2AF6E8EA008043B6 /* Date.swift in Sources */,
 				7E55A2ED2B028C880060CE66 /* HabitProgressMethod.swift in Sources */,
 				7E8460ED2AF6E8E3008043B6 /* Progress+CoreDataProperties.swift in Sources */,
+				7ECFBEA82B6853AC00935EA0 /* SmallMultiHabitView.swift in Sources */,
 				7E9684562AF9902900BBCAD4 /* HapticManager.swift in Sources */,
 				7ECFBEA62B6827FE00935EA0 /* HabitType.swift in Sources */,
 				7E5FFE762AFEE94A00C644A3 /* Action+CoreDataProperties.swift in Sources */,

--- a/Habiscus/AppIntents/HabitEntity.swift
+++ b/Habiscus/AppIntents/HabitEntity.swift
@@ -29,6 +29,12 @@ struct HabitEntity: AppEntity, Identifiable {
     @Property(title: "Ends on")
     var endDate: Date?
     
+    @Property(title: "Type")
+    var type: String
+    
+    @Property(title: "Progress method")
+    var progressMethod: String
+    
     @Property(title: "Icon")
     var icon: String
     
@@ -54,7 +60,7 @@ struct HabitEntity: AppEntity, Identifiable {
         URL(string: "habiscus://open-habit?id=\(id)")
     }
     
-    init(id: UUID, name: String?, createdAt: Date?, startDate: Date?, endDate: Date?, icon: String, color: String?, count: Int, goal: Int, unit: String, lastUpdated: Date?, isArchived: Bool) {
+    init(id: UUID, name: String?, createdAt: Date?, startDate: Date?, endDate: Date?, type: String?, progressMethod: String?, icon: String, color: String?, count: Int, goal: Int, unit: String, lastUpdated: Date?, isArchived: Bool) {
         let habitName = name ?? "Unknown name"
         
         self.id = id
@@ -62,6 +68,8 @@ struct HabitEntity: AppEntity, Identifiable {
         self.createdAt = createdAt ?? Date()
         self.startDate = startDate ?? Date()
         self.endDate = endDate
+        self.type = type ?? "build"
+        self.progressMethod = progressMethod ?? "counts"
         self.icon = icon
         self.color = color ?? "pink"
         self.count = count
@@ -77,6 +85,8 @@ struct HabitEntity: AppEntity, Identifiable {
         self.createdAt = habit.createdDate
         self.startDate = habit.startDate ?? Date()
         self.endDate = habit.endDate
+        self.type = habit.type ?? "build"
+        self.progressMethod = habit.progressMethod ?? "counts"
         self.icon = habit.emojiIcon
         self.color = habit.color ?? "pink"
         self.count = habit.getCountByDate(from: Date())
@@ -86,7 +96,9 @@ struct HabitEntity: AppEntity, Identifiable {
         self.isArchived = habit.isArchived
     }
     
-    static let example: HabitEntity = HabitEntity(id: UUID(), name: "Habit", createdAt: Date(), startDate: Date(), endDate: nil, icon: "👍", color: "blue", count: 1, goal: 2, unit: "completed", lastUpdated: Date(), isArchived: false)
+    static let example: HabitEntity = HabitEntity(id: UUID(), name: "Habit", createdAt: Date(), startDate: Date(), endDate: nil, type: "build", progressMethod: "counts", icon: "👍", color: "blue", count: 1, goal: 2, unit: "completed", lastUpdated: Date(), isArchived: false)
+    static let example2: HabitEntity = HabitEntity(id: UUID(), name: "Habit2", createdAt: Date(), startDate: Date(), endDate: nil, type: "build", progressMethod: "action", icon: "🎉", color: "pink", count: 4, goal: 5, unit: "add", lastUpdated: Date(), isArchived: false)
+    static let example3: HabitEntity = HabitEntity(id: UUID(), name: "Habit3", createdAt: Date(), startDate: Date(), endDate: nil, type: "quit", progressMethod: "counts", icon: "🚫", color: "green", count: 2, goal: 3, unit: "add", lastUpdated: Date(), isArchived: false)
 }
 
 struct HabitQuery: EntityPropertyQuery {

--- a/Habiscus/DataManagers/ActionManager.swift
+++ b/Habiscus/DataManagers/ActionManager.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import WidgetKit
 
 class ActionManager: ObservableObject {
     private let moc = DataController.shared.container.viewContext
@@ -65,6 +66,7 @@ class ActionManager: ObservableObject {
         if moc.hasChanges {
             try? moc.save()
         }
+        WidgetCenter.shared.reloadAllTimelines()
         currentAction = incompleteOrderedActions.first
     }
 }

--- a/Habiscus/DataManagers/HabitManager.swift
+++ b/Habiscus/DataManagers/HabitManager.swift
@@ -44,7 +44,7 @@ struct HabitManager {
         
         updateProgress(progress)
         try? moc.save()
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     // Makes sure the date is today or earlier
@@ -99,7 +99,7 @@ struct HabitManager {
         habit.lastUpdated = Date()
         
         try? moc.save()
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     func setProgressSkip(_ habit: Habit? = nil, progress: Progress, skip: Bool) {
@@ -109,7 +109,7 @@ struct HabitManager {
         habit.lastUpdated = Date()
         
         try? moc.save()
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     func skipNewProgress(_ habit: Habit? = nil, on date: Date) {
@@ -131,7 +131,7 @@ struct HabitManager {
         habit.lastUpdated = Date()
         
         try? moc.save()
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     func undoAction(action: Action) {
@@ -145,7 +145,7 @@ struct HabitManager {
         progress.habit?.lastUpdated = Date()
         
         try? moc.save()
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     // TODO: Rewrite weekly code
@@ -178,7 +178,7 @@ struct HabitManager {
         } catch let error {
             print(error.localizedDescription)
         }
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     func unarchiveHabit(_ habit: Habit? = nil) throws {
@@ -187,7 +187,7 @@ struct HabitManager {
         }
         habit.isArchived = false
         try? moc.save()
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     func removeHabit(_ habit: Habit? = nil) throws {
@@ -197,7 +197,7 @@ struct HabitManager {
         removeAllNotifications(habit)
         moc.delete(habit)
         try? moc.save()
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     func removeHabit(_ habit: Habit? = nil, toastManager: ToastManager) throws {
@@ -219,7 +219,7 @@ struct HabitManager {
             toastManager.showAlert = true
             HapticManager.shared.simpleError()
         }
-        WidgetCenter.shared.reloadTimelines(ofKind: "HabitWidget")
+        WidgetCenter.shared.reloadAllTimelines()
     }
     
     func removeAllNotifications(_ habit: Habit? = nil) {

--- a/Habiscus/DataManagers/HabitsManager.swift
+++ b/Habiscus/DataManagers/HabitsManager.swift
@@ -58,7 +58,12 @@ class HabitsManager: ObservableObject {
         }
     }
     
-    func findHabits(for ids: [UUID]) throws -> [Habit] {
+    func findHabits(for ids: [UUID], refresh: Bool = false) throws -> [Habit] {
+        if refresh {
+            try? self.context.setQueryGenerationFrom(.current)
+            self.context.refreshAllObjects()
+        }
+        
         let request: NSFetchRequest<Habit> = Habit.fetchRequest()
         request.predicate = NSPredicate(format: "id IN %@", ids)
         do {

--- a/HabiscusWidget/HabiscusWidgetBundle.swift
+++ b/HabiscusWidget/HabiscusWidgetBundle.swift
@@ -12,5 +12,6 @@ import SwiftUI
 struct HabiscusWidgetBundle: WidgetBundle {
     var body: some Widget {
         HabiscusWidget()
+        MultiHabitWidget()
     }
 }

--- a/HabiscusWidget/Intents/HabitIntent.swift
+++ b/HabiscusWidget/Intents/HabitIntent.swift
@@ -25,6 +25,24 @@ struct WidgetHabitSelection: WidgetConfigurationIntent {
     }
 }
 
+struct WidgetMultiHabitSelection: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Select Multiple Habits"
+    static var description = IntentDescription("Select habits to display")
+    
+    @Parameter(title: "Habits")
+    var habits: [HabitEntity]
+    
+    init(habits: [HabitEntity]) {
+        self.habits = habits
+    }
+    
+    init() {}
+    
+    func perform() async throws -> some IntentResult {
+        return .result()
+    }
+}
+
 struct AddCountToHabit: AppIntent {
     static var title: LocalizedStringResource = "Add count"
     

--- a/HabiscusWidget/MultiHabitWidget.swift
+++ b/HabiscusWidget/MultiHabitWidget.swift
@@ -1,0 +1,158 @@
+//
+//  MultiHabitWidget.swift
+//  HabiscusWidgetExtension
+//
+//  Created by Skylar Clemens on 1/29/24.
+//
+
+import WidgetKit
+import SwiftUI
+import CoreData
+
+struct MultiHabitEntry: TimelineEntry {
+    var habits: [HabitEntity]?
+    public let date: Date
+    
+    static var placeholder: Self {
+        Self(habits: [HabitEntity.example, HabitEntity.example2, HabitEntity.example3], date: .now)
+    }
+}
+
+struct MultiHabitIntentProvider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> MultiHabitEntry {
+        MultiHabitEntry.placeholder
+    }
+    
+    func snapshot(for configuration: WidgetMultiHabitSelection, in context: Context) async -> MultiHabitEntry {
+        let ids = configuration.habits.map { $0.id }
+        let habits = try? HabitsManager.shared.findHabits(for: ids, refresh: true)
+        if let habits {
+            var habitEntities: [HabitEntity] = []
+            for habit in habits {
+                let habitEntity = HabitEntity(habit: habit)
+                habitEntities.append(habitEntity)
+            }
+            return MultiHabitEntry(habits: habitEntities, date: .now)
+        }
+        return MultiHabitEntry.placeholder
+    }
+    
+    func timeline(for configuration: WidgetMultiHabitSelection, in context: Context) async -> Timeline<MultiHabitEntry> {
+        let ids = configuration.habits.map { $0.id }
+        let habits = try? HabitsManager.shared.findHabits(for: ids, refresh: true)
+        
+        var entries: [MultiHabitEntry] = []
+        if let habits {
+            var habitEntities: [HabitEntity] = []
+            for habit in habits {
+                let habitEntity = HabitEntity(habit: habit)
+                habitEntities.append(habitEntity)
+            }
+            let entry = MultiHabitEntry(habits: habitEntities, date: .now)
+            entries.append(entry)
+        }
+        let startOfToday = Calendar.current.startOfDay(for: Date())
+        let startOfTomorrow = Calendar.current.date(byAdding: .day, value: 1, to: startOfToday)
+        return Timeline(entries: entries, policy: .after(startOfTomorrow ?? Date()))
+    }
+}
+
+struct MultiHabitProvider: TimelineProvider {
+    func placeholder(in context: Context) -> MultiHabitEntry {
+        MultiHabitEntry.placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (MultiHabitEntry) -> ()) {
+        do {
+            let habits = try HabitsManager.shared.getAllActiveHabits()
+            
+            var habitEntities: [HabitEntity] = []
+            let habitSlice = habits[0..<4]
+            for habit in habitSlice {
+                let habitEntity = HabitEntity(habit: habit)
+                habitEntities.append(habitEntity)
+            }
+            
+            let entry = MultiHabitEntry(habits: habitEntities, date: .now)
+            completion(entry)
+        } catch {
+            print(error)
+        }
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> ()) {
+        do {
+            let habits = try HabitsManager.shared.getAllActiveHabits()
+            var habitEntities: [HabitEntity] = []
+            var entries: [MultiHabitEntry] = []
+
+            let entryDate: Date = .now
+            let habitSlice = habits[0..<4]
+            for habit in habitSlice {
+                let habitEntity = HabitEntity(habit: habit)
+                habitEntities.append(habitEntity)
+            }
+            
+            let entry = MultiHabitEntry(habits: habitEntities, date: entryDate)
+            entries.append(entry)
+            
+            let startOfToday = Calendar.current.startOfDay(for: Date())
+            let startOfTomorrow = Calendar.current.date(byAdding: .day, value: 1, to: startOfToday)
+            let timeline = Timeline(entries: entries, policy: .after(startOfTomorrow ?? Date()))
+            completion(timeline)
+        } catch {
+            print(error)
+        }
+    }
+}
+
+struct MultiHabitWidgetEntryView : View {
+    var entry: MultiHabitProvider.Entry
+
+    var body: some View {
+        VStack {
+            if let habits = entry.habits {
+                SmallMultiHabitView(habits: habits)
+            }
+        }
+    }
+}
+
+struct MultiHabitWidget: Widget {
+    let dataController = DataController.shared
+    let kind: String = "Multi Habit Widget"
+
+    var body: some WidgetConfiguration {
+        makeWidgetConfiguration()
+            .configurationDisplayName("Multiple Habits")
+            .description("Keep track of multiple habits.")
+    }
+    
+    func makeWidgetConfiguration() -> some WidgetConfiguration {
+        if #available(iOS 17.0, *) {
+            return AppIntentConfiguration(kind: kind,
+                                          intent: WidgetMultiHabitSelection.self,
+                                          provider: MultiHabitIntentProvider()) { entry in
+                MultiHabitWidgetEntryView(entry: entry)
+                    .padding()
+            }.supportedFamilies([.systemSmall])
+                .contentMarginsDisabled()
+        } else {
+            return StaticConfiguration(kind: kind, provider: MultiHabitProvider()) { entry in
+                MultiHabitWidgetEntryView(entry: entry)
+                    .background()
+                    .environment(\.managedObjectContext, dataController.container.viewContext)
+            }.supportedFamilies([.systemSmall])
+        }
+    }
+}
+
+struct MultiHabitWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        Previewing(\.habit) { habit in
+            let entry = MultiHabitEntry(habits: [HabitEntity(habit: habit)], date: Date())
+            MultiHabitWidgetEntryView(entry: entry)
+                .previewContext(WidgetPreviewContext(family: .systemSmall))
+        }
+    }
+}

--- a/HabiscusWidget/Views/SmallHabitView.swift
+++ b/HabiscusWidget/Views/SmallHabitView.swift
@@ -16,12 +16,14 @@ struct SmallHabitView: View {
             HStack {
                 WidgetGoalCounter(size: 40, date: Date(), count: habit.count, goal: habit.goal, icon: habit.icon, checkmarkSize: 10)
                 Spacer()
-                if #available(iOS 17.0, *) {
-                    Button(intent: AddCountToHabit(habit: habit, date: Date())) {
-                        Label("Add", systemImage: "plus")
+                if habit.progressMethod == "counts" {
+                    if #available(iOS 17.0, *) {
+                        Button(intent: AddCountToHabit(habit: habit, date: Date())) {
+                            Label("Add", systemImage: "plus")
+                        }
+                        .labelStyle(.iconOnly)
+                        .tint(.white)
                     }
-                    .labelStyle(.iconOnly)
-                    .tint(.white)
                 }
             }
             HStack {
@@ -64,42 +66,6 @@ struct SmallHabitView: View {
     }
 }
 
-struct WidgetGoalCounter: View {
-    var size: CGFloat = 50
-    var date: Date
-    var count: Int
-    var goal: Int
-    var icon: String
-    var checkmarkSize: CGFloat = 15
-    
-    private var goalCompletion: Double {
-        Double(count) / Double(goal)
-    }
-    
-    var body: some View {
-        ZStack {
-            HStack {
-                if goalCompletion >= 1 {
-                    AnimatedCheckmark(animationDuration: 1.25, size: checkmarkSize)
-                } else {
-                    if !icon.isEmpty {
-                        IconView(char: icon, size: 16)
-                    } else {
-                        Text(count, format: .number)
-                            .font(.system(.title2, design: .rounded))
-                            .bold()
-                            .foregroundColor(.white)
-                    }
-                }
-            }
-            ProgressView(value: goalCompletion > 1 ? 1.0 : goalCompletion, total: 1.0)
-                .progressViewStyle(CircleProgressStyle(color: .white, strokeWidth: 6))
-                .frame(width: size)
-                .animation(.easeOut(duration: 1.25), value: count)
-        }
-    }
-}
-
 struct SmallHabitView_Previews: PreviewProvider {
     static var previews: some View {
         SmallHabitView(habit: HabitEntity.example)
@@ -112,4 +78,3 @@ struct SmallHabitView_Previews: PreviewProvider {
 } timeline: {
     SimpleEntry(habit: HabitEntity.example, date: Date())
 }*/
-

--- a/HabiscusWidget/Views/SmallMultiHabitView.swift
+++ b/HabiscusWidget/Views/SmallMultiHabitView.swift
@@ -1,0 +1,50 @@
+//
+//  SmallMultiHabitView.swift
+//  HabiscusWidgetExtension
+//
+//  Created by Skylar Clemens on 1/29/24.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct SmallMultiHabitView: View {
+    @State var habits: [HabitEntity]
+    let columns = [GridItem(.flexible(), alignment: .center), GridItem(.flexible(), alignment: .center)]
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            LazyVGrid(columns: columns, spacing: 10) {
+                ForEach(habits) { habit in
+                    if #available(iOS 17.0, *) {
+                        if habit.progressMethod == "counts" {
+                            Button(intent: AddCountToHabit(habit: habit, date: Date())) {
+                                WidgetGoalCounter(size: 50, date: Date(), count: habit.count, goal: habit.goal, icon: habit.icon, habitType: habit.type, showCheckmark: false, color: Color(habit.color))
+                            }
+                            .buttonStyle(.plain)
+                            .padding(5)
+                            .shadow(color: Color.black.opacity(0.1), radius: 3, y: 0)
+                            .shadow(color: Color(habit.color).opacity(0.2), radius: 2, y: 0)
+                        } else {
+                            Link(destination: habit.url!) {
+                                WidgetGoalCounter(size: 50, date: Date(), count: habit.count, goal: habit.goal, icon: habit.icon, habitType: habit.type, showCheckmark: false, color: Color(habit.color))
+                            }
+                        }
+                    } else {
+                        WidgetGoalCounter(size: 50, date: Date(), count: habit.count, goal: habit.goal, icon: habit.icon, showCheckmark: false, color: Color(habit.color))
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
+        .widgetBackground(Color(UIColor.systemBackground))
+    }
+}
+
+struct SmallMultiHabitView_Previews: PreviewProvider {
+    static var previews: some View {
+        SmallMultiHabitView(habits: [HabitEntity.example, HabitEntity.example2, HabitEntity.example3])
+            .previewContext(WidgetPreviewContext(family: .systemSmall))
+    }
+}

--- a/HabiscusWidget/Views/WidgetGoalCounter.swift
+++ b/HabiscusWidget/Views/WidgetGoalCounter.swift
@@ -1,0 +1,63 @@
+//
+//  WidgetGoalCounter.swift
+//  HabiscusWidgetExtension
+//
+//  Created by Skylar Clemens on 1/30/24.
+//
+
+import SwiftUI
+import WidgetKit
+
+struct WidgetGoalCounter: View {
+    var size: CGFloat = 50
+    var date: Date
+    var count: Int
+    var goal: Int
+    var icon: String
+    var habitType: String = "build"
+    var showCheckmark: Bool = true
+    var checkmarkSize: CGFloat = 15
+    var color: Color = .white
+    
+    private var goalCompletion: Double {
+        let goalCount = Double(count) / Double(goal)
+        if habitType == "quit" {
+            let quitCount = 1 - goalCount
+            return min(max(quitCount, 0), 1)
+        }
+        return min(max(goalCount, 0), 1)
+    }
+    
+    var body: some View {
+        ZStack {
+            HStack {
+                if goalCompletion >= 1 && showCheckmark {
+                    AnimatedCheckmark(animationDuration: 1.25, size: checkmarkSize)
+                } else {
+                    if !icon.isEmpty {
+                        IconView(char: icon, size: 16)
+                    } else {
+                        Text(count, format: .number)
+                            .font(.system(.title2, design: .rounded))
+                            .bold()
+                            .foregroundColor(color)
+                    }
+                }
+            }
+            ProgressView(value: goalCompletion > 1 ? 1.0 : goalCompletion, total: 1.0)
+                .progressViewStyle(CircleProgressStyle(color: color, strokeWidth: 6))
+                .frame(width: size)
+                .animation(.easeOut(duration: 1.25), value: count)
+        }
+    }
+}
+
+struct WidgetGoalCounter_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            WidgetGoalCounter(size: 50, date: Date(), count: 1, goal: 2, icon: "🤩", habitType: "build", checkmarkSize: 10)
+        }
+        .previewContext(WidgetPreviewContext(family: .systemSmall))
+        .widgetBackground(Color.pink)
+    }
+}

--- a/Habit+CoreDataProperties.swift
+++ b/Habit+CoreDataProperties.swift
@@ -178,17 +178,15 @@ extension Habit {
     }
     
     public func findProgress(from date: Date) -> Progress? {
+        guard !self.progressArray.isEmpty else { return nil }
         var progressDate = date
         if goalFrequency == "weekly" {
             progressDate = date.startOfWeek()
         }
-        if let progressObjects = self.progress?.allObjects as? [Progress],
-           let progressOnDate = progressObjects.first(where: {
-               Calendar.current.isDate($0.wrappedDate, inSameDayAs: progressDate)
-           }) {
-            return progressOnDate
-        }
-        return nil
+        let progressOnDate = self.progressArray.first(where: {
+            Calendar.current.isDate($0.wrappedDate, inSameDayAs: progressDate)
+        })
+        return progressOnDate
     }
     
     public func lastUpdatedProgress() -> Progress {


### PR DESCRIPTION
- Create widget to show multiple habits
- Allow user to update count from widget (for action habits, user will be redirected to app)
- Update Widget Goal Counter to work for new types of habits and different configurations
- Update HabitEntity to support progress types and habit types